### PR TITLE
[feat] 이력서 피드백 전체 조회

### DIFF
--- a/backend/src/main/java/com/techeer/backend/api/feedback/controller/FeedbackController.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/controller/FeedbackController.java
@@ -1,5 +1,6 @@
 package com.techeer.backend.api.feedback.controller;
 
+import com.techeer.backend.api.feedback.dto.FeedbackListResponse;
 import com.techeer.backend.api.feedback.service.FeedbackService;
 import com.techeer.backend.api.feedback.dto.FeedbackCreateRequest;
 import com.techeer.backend.api.feedback.dto.FeedbackResponse;
@@ -22,7 +23,6 @@ public class FeedbackController {
 
     private final FeedbackService feedbackService;
 
-
     @Operation(summary = "피드백 등록", description = "원하는 위치에 피드백을 작성합니다.")
     @PostMapping("/{resume_id}/feedbacks")
     public ResponseEntity<FeedbackResponse> createFeedback(
@@ -42,6 +42,13 @@ public class FeedbackController {
         log.info("피드백 생성 완료: {}", feedbackResponse);
 
         return new ResponseEntity<>(feedbackResponse, HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "피드백 리스트 조회", description = "특정 이력서의 피드백 전체를 리스트로 전달")
+    @GetMapping("/{resume_id}/feedbacks")
+    public ResponseEntity<FeedbackListResponse> getFeedback(@PathVariable Long resume_id) {
+        FeedbackListResponse response = feedbackService.getFeedbackList(resume_id);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "피드백 삭제")

--- a/backend/src/main/java/com/techeer/backend/api/feedback/controller/FeedbackController.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/controller/FeedbackController.java
@@ -1,9 +1,9 @@
 package com.techeer.backend.api.feedback.controller;
 
-import com.techeer.backend.api.feedback.dto.FeedbackListResponse;
+import com.techeer.backend.api.feedback.dto.Response.FeedbackListResponse;
 import com.techeer.backend.api.feedback.service.FeedbackService;
-import com.techeer.backend.api.feedback.dto.FeedbackCreateRequest;
-import com.techeer.backend.api.feedback.dto.FeedbackResponse;
+import com.techeer.backend.api.feedback.dto.Request.FeedbackCreateRequest;
+import com.techeer.backend.api.feedback.dto.Response.FeedbackResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;

--- a/backend/src/main/java/com/techeer/backend/api/feedback/dto/FeedbackListResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/dto/FeedbackListResponse.java
@@ -1,0 +1,26 @@
+package com.techeer.backend.api.feedback.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.techeer.backend.api.feedback.domain.Feedback;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class FeedbackListResponse {
+
+    private Long resumeId;
+
+    private List<Feedback> feedbacks;
+
+    private FeedbackListResponse(Long resumeId, List<Feedback> feedbacks){
+        this.resumeId = resumeId;
+        this.feedbacks = feedbacks;
+    }
+
+    public static  FeedbackListResponse from(Long resumeId, List<Feedback> feedbacks){
+        return new FeedbackListResponse(resumeId, feedbacks);
+    }
+}

--- a/backend/src/main/java/com/techeer/backend/api/feedback/dto/Request/FeedbackCreateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/dto/Request/FeedbackCreateRequest.java
@@ -1,4 +1,4 @@
-package com.techeer.backend.api.feedback.dto;
+package com.techeer.backend.api.feedback.dto.Request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/com/techeer/backend/api/feedback/dto/Response/FeedbackListResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/dto/Response/FeedbackListResponse.java
@@ -3,12 +3,15 @@ package com.techeer.backend.api.feedback.dto.Response;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.techeer.backend.api.feedback.domain.Feedback;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
+@Builder
+@RequiredArgsConstructor
 @Getter
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class FeedbackListResponse {
 
     private Long resumeId;

--- a/backend/src/main/java/com/techeer/backend/api/feedback/dto/Response/FeedbackListResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/dto/Response/FeedbackListResponse.java
@@ -1,4 +1,4 @@
-package com.techeer.backend.api.feedback.dto;
+package com.techeer.backend.api.feedback.dto.Response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -13,14 +13,14 @@ public class FeedbackListResponse {
 
     private Long resumeId;
 
-    private List<Feedback> feedbacks;
+    private List<FeedbackResponse> feedbacks;
 
-    private FeedbackListResponse(Long resumeId, List<Feedback> feedbacks){
+    private FeedbackListResponse(Long resumeId, List<FeedbackResponse> feedbacks){
         this.resumeId = resumeId;
         this.feedbacks = feedbacks;
     }
 
-    public static  FeedbackListResponse from(Long resumeId, List<Feedback> feedbacks){
+    public static  FeedbackListResponse from(Long resumeId, List<FeedbackResponse> feedbacks){
         return new FeedbackListResponse(resumeId, feedbacks);
     }
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/dto/Response/FeedbackResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/dto/Response/FeedbackResponse.java
@@ -3,10 +3,13 @@ package com.techeer.backend.api.feedback.dto.Response;
 import com.techeer.backend.api.feedback.domain.Feedback;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.math.BigDecimal;
 
+@Builder
 @Getter
+@RequiredArgsConstructor
 public class FeedbackResponse {
 
     private final Long feedbackId;
@@ -14,15 +17,6 @@ public class FeedbackResponse {
     private final String content;
     private final BigDecimal xCoordinate;
     private final BigDecimal yCoordinate;
-
-    @Builder
-    private FeedbackResponse(Long feedbackId, Long resumeId, String content, BigDecimal xCoordinate, BigDecimal yCoordinate) {
-        this.feedbackId = feedbackId;
-        this.resumeId = resumeId;
-        this.content = content;
-        this.xCoordinate = xCoordinate;
-        this.yCoordinate = yCoordinate;
-    }
 
     private FeedbackResponse(Feedback feedback) {
         this.feedbackId = feedback.getId();
@@ -32,18 +26,17 @@ public class FeedbackResponse {
         this.yCoordinate = feedback.getYCoordinate();
     }
 
-    public static FeedbackResponse from(Long feedbackId, Long resumeId, String content, BigDecimal xCoordinate, BigDecimal yCoordinate) {
-        return FeedbackResponse.builder()
-                .feedbackId(feedbackId)
-                .resumeId(resumeId)
-                .content(content)
-                .xCoordinate(xCoordinate)
-                .yCoordinate(yCoordinate)
-                .build();
-    }
+//    public static FeedbackResponse from(Long feedbackId, Long resumeId, String content, BigDecimal xCoordinate, BigDecimal yCoordinate) {
+//        return FeedbackResponse.builder()
+//                .feedbackId(feedbackId)
+//                .resumeId(resumeId)
+//                .content(content)
+//                .xCoordinate(xCoordinate)
+//                .yCoordinate(yCoordinate)
+//                .build();
+//    }
 
     public static FeedbackResponse of(Feedback feedback){
-
         return new FeedbackResponse(feedback);
     }
 

--- a/backend/src/main/java/com/techeer/backend/api/feedback/dto/Response/FeedbackResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/dto/Response/FeedbackResponse.java
@@ -1,5 +1,6 @@
-package com.techeer.backend.api.feedback.dto;
+package com.techeer.backend.api.feedback.dto.Response;
 
+import com.techeer.backend.api.feedback.domain.Feedback;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -23,7 +24,15 @@ public class FeedbackResponse {
         this.yCoordinate = yCoordinate;
     }
 
-    public static FeedbackResponse of(Long feedbackId, Long resumeId, String content, BigDecimal xCoordinate, BigDecimal yCoordinate) {
+    private FeedbackResponse(Feedback feedback) {
+        this.feedbackId = feedback.getId();
+        this.resumeId = feedback.getResume().getId();
+        this.content = feedback.getContent();
+        this.xCoordinate = feedback.getXCoordinate();
+        this.yCoordinate = feedback.getYCoordinate();
+    }
+
+    public static FeedbackResponse from(Long feedbackId, Long resumeId, String content, BigDecimal xCoordinate, BigDecimal yCoordinate) {
         return FeedbackResponse.builder()
                 .feedbackId(feedbackId)
                 .resumeId(resumeId)
@@ -32,4 +41,10 @@ public class FeedbackResponse {
                 .yCoordinate(yCoordinate)
                 .build();
     }
+
+    public static FeedbackResponse of(Feedback feedback){
+
+        return new FeedbackResponse(feedback);
+    }
+
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/service/FeedbackService.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/service/FeedbackService.java
@@ -75,18 +75,21 @@ public class FeedbackService {
 
     public FeedbackListResponse getFeedbackList(Long resumeId){
         List<Feedback> feedbacks= feedbackRepository.findAllByResumeId(resumeId);
-        List<FeedbackResponse> feedbackList= feedbacks.stream().map(FeedbackResponse::of).toList();
+        List<FeedbackResponse> feedbackList = feedbacks.stream().map(FeedbackResponse::of).toList();
 
-        return FeedbackListResponse.from(resumeId, feedbackList);
+        return FeedbackListResponse.builder()
+                .feedbacks(feedbackList)
+                .resumeId(resumeId)
+                .build();
     }
 
     private FeedbackResponse toFeedbackResponse(Feedback feedback) {
-        return FeedbackResponse.from(
-                feedback.getId(),
-                feedback.getResume().getId(),
-                feedback.getContent(),
-                feedback.getXCoordinate(),
-                feedback.getYCoordinate()
-        );
+        return FeedbackResponse.builder()
+                .feedbackId(feedback.getId())
+                .resumeId(feedback.getResume().getId())
+                .content(feedback.getContent())
+                .xCoordinate(feedback.getXCoordinate())
+                .yCoordinate(feedback.getYCoordinate())
+                .build();
     }
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/service/FeedbackService.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/service/FeedbackService.java
@@ -1,12 +1,13 @@
 package com.techeer.backend.api.feedback.service;
 
-import com.techeer.backend.api.feedback.dto.FeedbackListResponse;
+import com.techeer.backend.api.feedback.dto.Response.FeedbackListResponse;
 import com.techeer.backend.api.feedback.repository.FeedbackRepository;
 
-import com.techeer.backend.api.feedback.dto.FeedbackResponse;
+import com.techeer.backend.api.feedback.dto.Response.FeedbackResponse;
 import com.techeer.backend.api.feedback.domain.Feedback;
 
 import com.techeer.backend.api.resume.domain.Resume;
+import com.techeer.backend.api.resume.dto.response.ResumeResponse;
 import com.techeer.backend.api.resume.repository.ResumeRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -73,13 +74,14 @@ public class FeedbackService {
     }
 
     public FeedbackListResponse getFeedbackList(Long resumeId){
-        List<Feedback> feedbackList = feedbackRepository.findAllByResumeId(resumeId);
+        List<Feedback> feedbacks= feedbackRepository.findAllByResumeId(resumeId);
+        List<FeedbackResponse> feedbackList= feedbacks.stream().map(FeedbackResponse::of).toList();
 
         return FeedbackListResponse.from(resumeId, feedbackList);
     }
 
     private FeedbackResponse toFeedbackResponse(Feedback feedback) {
-        return FeedbackResponse.of(
+        return FeedbackResponse.from(
                 feedback.getId(),
                 feedback.getResume().getId(),
                 feedback.getContent(),

--- a/backend/src/main/java/com/techeer/backend/api/feedback/service/FeedbackService.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/service/FeedbackService.java
@@ -1,5 +1,6 @@
 package com.techeer.backend.api.feedback.service;
 
+import com.techeer.backend.api.feedback.dto.FeedbackListResponse;
 import com.techeer.backend.api.feedback.repository.FeedbackRepository;
 
 import com.techeer.backend.api.feedback.dto.FeedbackResponse;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -70,7 +72,11 @@ public class FeedbackService {
         feedbackRepository.delete(feedback);
     }
 
+    public FeedbackListResponse getFeedbackList(Long resumeId){
+        List<Feedback> feedbackList = feedbackRepository.findAllByResumeId(resumeId);
 
+        return FeedbackListResponse.from(resumeId, feedbackList);
+    }
 
     private FeedbackResponse toFeedbackResponse(Feedback feedback) {
         return FeedbackResponse.of(

--- a/backend/src/main/java/com/techeer/backend/api/resume/controller/ResumeController.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/controller/ResumeController.java
@@ -77,12 +77,12 @@ public class ResumeController {
     //todo 피드백 완성되면 작업
     @Operation(summary = "이력서 개별 조회")
     @GetMapping("/resumes/{resume_id}")
-    public ResponseEntity<SuccessResponse> fetchResumeContent(@PathVariable("resume_id") Long resumeId) throws IOException {
+    public ResponseEntity<FetchResumeContentResponse> fetchResumeContent(@PathVariable("resume_id") Long resumeId) throws IOException {
 
         FetchResumeContentResponse resumeContent = resumeService.getResumeContent(resumeId);
-        SuccessResponse response = SuccessResponse.of(SuccessCode.SUCCESS, resumeContent);
+        //SuccessResponse response = SuccessResponse.of(SuccessCode.SUCCESS, resumeContent);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(resumeContent);
     }
     
     @Operation(summary = "이력서 여러 조회")
@@ -91,7 +91,6 @@ public class ResumeController {
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         //ResumeService를 통해 페이지네이션된 이력서 목록을 가져옵니다.
         ResumePageResponse resumes = resumeService.getResumePage(pageable);
-
         return ResponseEntity.ok(resumes);
     }
 }

--- a/backend/src/main/java/com/techeer/backend/api/resume/dto/request/CreateResumeRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/dto/request/CreateResumeRequest.java
@@ -6,6 +6,7 @@ import com.techeer.backend.api.resume.domain.Position;
 import com.techeer.backend.api.resume.domain.Resume;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;

--- a/backend/src/main/java/com/techeer/backend/api/resume/dto/response/FetchResumeContentResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/dto/response/FetchResumeContentResponse.java
@@ -4,6 +4,7 @@ package com.techeer.backend.api.resume.dto.response;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.techeer.backend.api.feedback.domain.Feedback;
+import com.techeer.backend.api.feedback.dto.Response.FeedbackResponse;
 import com.techeer.backend.api.resume.domain.Position;
 import com.techeer.backend.api.resume.domain.Resume;
 import com.techeer.backend.api.resume.domain.ResumeTechStack;
@@ -21,10 +22,10 @@ public class FetchResumeContentResponse {
     private int career;
     private List<ResumeTechStack> techStack;
     private String fileUrl;
-    private List<Feedback> feedbacks;
+    private List<FeedbackResponse> feedbacks;
 
     private FetchResumeContentResponse(Long id, String username, Position position, int career,
-                                       List<ResumeTechStack> techStack, String fileUrl, List<Feedback> feedbacks) {
+                                       List<ResumeTechStack> techStack, String fileUrl, List<FeedbackResponse> feedbacks) {
         this.resumeId = id;
         this.userName = username;
         this.position = position;
@@ -34,7 +35,7 @@ public class FetchResumeContentResponse {
         this.feedbacks = feedbacks;
     }
 
-    public static FetchResumeContentResponse from(Resume resume, List<Feedback> feedbacks){
+    public static FetchResumeContentResponse from(Resume resume, List<FeedbackResponse> feedbacks){
         return new FetchResumeContentResponse(resume.getId(),
                 resume.getUsername(), resume.getPosition(), resume.getCareer(), resume.getResumeTechStacks(),
                 resume.getUrl(), feedbacks);

--- a/backend/src/main/java/com/techeer/backend/api/resume/dto/response/FetchResumeContentResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/dto/response/FetchResumeContentResponse.java
@@ -15,13 +15,13 @@ import java.util.List;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class FetchResumeContentResponse {
 
-    private final Long resumeId;
-    private final String userName;
-    private final Position position;
-    private final int career;
-    private final List<ResumeTechStack> techStack;
-    private final String fileUrl;
-    private final List<Feedback> feedbacks;
+    private Long resumeId;
+    private String userName;
+    private Position position;
+    private int career;
+    private List<ResumeTechStack> techStack;
+    private String fileUrl;
+    private List<Feedback> feedbacks;
 
     private FetchResumeContentResponse(Long id, String username, Position position, int career,
                                        List<ResumeTechStack> techStack, String fileUrl, List<Feedback> feedbacks) {

--- a/backend/src/main/java/com/techeer/backend/api/resume/dto/response/FetchResumeContentResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/dto/response/FetchResumeContentResponse.java
@@ -3,15 +3,18 @@ package com.techeer.backend.api.resume.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.techeer.backend.api.feedback.domain.Feedback;
 import com.techeer.backend.api.feedback.dto.Response.FeedbackResponse;
 import com.techeer.backend.api.resume.domain.Position;
 import com.techeer.backend.api.resume.domain.Resume;
 import com.techeer.backend.api.resume.domain.ResumeTechStack;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
+@RequiredArgsConstructor
+@Builder
 @Getter
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class FetchResumeContentResponse {
@@ -24,22 +27,15 @@ public class FetchResumeContentResponse {
     private String fileUrl;
     private List<FeedbackResponse> feedbacks;
 
-    private FetchResumeContentResponse(Long id, String username, Position position, int career,
-                                       List<ResumeTechStack> techStack, String fileUrl, List<FeedbackResponse> feedbacks) {
-        this.resumeId = id;
-        this.userName = username;
-        this.position = position;
-        this.career = career;
-        this.techStack = techStack;
-        this.fileUrl = fileUrl;
-        this.feedbacks = feedbacks;
-    }
 
-    public static FetchResumeContentResponse from(Resume resume, List<FeedbackResponse> feedbacks){
-        return new FetchResumeContentResponse(resume.getId(),
-                resume.getUsername(), resume.getPosition(), resume.getCareer(), resume.getResumeTechStacks(),
-                resume.getUrl(), feedbacks);
-    }
+//    public static FetchResumeContentResponse from(Resume resume, List<FeedbackResponse> feedbacks){
+//        return new FetchResumeContentResponse(resume.getId(),
+//                resume.getUsername(), resume.getPosition(), resume.getCareer(), resume.getResumeTechStacks(),
+//                resume.getUrl(), feedbacks);
+//    }
+
+
+
 
 }
 

--- a/backend/src/main/java/com/techeer/backend/api/resume/dto/response/ResumePageElement.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/dto/response/ResumePageElement.java
@@ -3,11 +3,13 @@ package com.techeer.backend.api.resume.dto.response;
 import com.techeer.backend.api.resume.domain.Position;
 import com.techeer.backend.api.resume.domain.Resume;
 import com.techeer.backend.api.resume.domain.ResumeTechStack;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
+@Builder
 @Getter
 @RequiredArgsConstructor
 public class ResumePageElement {

--- a/backend/src/main/java/com/techeer/backend/api/resume/dto/response/ResumePageResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/dto/response/ResumePageResponse.java
@@ -2,12 +2,14 @@ package com.techeer.backend.api.resume.dto.response;
 
 
 import com.techeer.backend.api.resume.domain.Resume;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
+@Builder
 @Getter
 @RequiredArgsConstructor
 public class ResumePageResponse {
@@ -16,13 +18,13 @@ public class ResumePageResponse {
     private int totalPage;
     private int currentPage;
 
-    private ResumePageResponse(List<ResumePageElement> elementList, int totalPages, int number) {
-        this.elementList = elementList;
-        this.totalPage = totalPages;
-        this.currentPage = number;
-    }
-
-    public static ResumePageResponse from(List<ResumePageElement> elementList , Page<Resume> page) {
-        return new ResumePageResponse(elementList, page.getTotalPages(), page.getNumber());
-    }
+//    private ResumePageResponse(List<ResumePageElement> elementList, int totalPages, int number) {
+//        this.elementList = elementList;
+//        this.totalPage = totalPages;
+//        this.currentPage = number;
+//    }
+//
+//    public static ResumePageResponse from(List<ResumePageElement> elementList , Page<Resume> page) {
+//        return new ResumePageResponse(elementList, page.getTotalPages(), page.getNumber());
+//    }
 }

--- a/backend/src/main/java/com/techeer/backend/api/resume/dto/response/ResumeResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/dto/response/ResumeResponse.java
@@ -2,17 +2,21 @@ package com.techeer.backend.api.resume.dto.response;
 
 import com.techeer.backend.api.resume.domain.Resume;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
+@Builder
 @Getter
 @AllArgsConstructor
 public class ResumeResponse {
-    private final Long resumeId;
-    private final String userName;
-    private final String resumeName;
-    private final String fileUrl;
+    private Long resumeId;
+    private String userName;
+    private String resumeName;
+    private String fileUrl;
 
-    public static ResumeResponse from(Resume resume) {
+    public static ResumeResponse of(Resume resume) {
         return new ResumeResponse(
                 resume.getId(),
                 resume.getUsername(),

--- a/backend/src/main/java/com/techeer/backend/api/resume/service/ResumeService.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/service/ResumeService.java
@@ -63,7 +63,6 @@ public class ResumeService {
         resumeRepository.save(resume);
     }
 
-    //todo 피드백까지 생기면
     @Transactional(readOnly = true)
     public FetchResumeContentResponse getResumeContent(Long resumeId) throws IOException {
         // 이력서 찾기

--- a/backend/src/main/java/com/techeer/backend/api/resume/service/ResumeService.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/service/ResumeService.java
@@ -74,13 +74,21 @@ public class ResumeService {
         List<Feedback> feedbacks = feedbackRepository.findAllByResumeId(resumeId);
         List<FeedbackResponse> feedbackList= feedbacks.stream().map(FeedbackResponse::of).toList();
         // FetchResumeContentResponse 객체 생성 후 반환
-        return FetchResumeContentResponse.from(resume, feedbackList);
+        return FetchResumeContentResponse.builder()
+                .resumeId(resume.getId())
+                .userName(resume.getUsername())
+                .position(resume.getPosition())
+                .career(resume.getCareer())
+                .techStack(resume.getResumeTechStacks())
+                .fileUrl(resume.getUrl())
+                .feedbacks(feedbackList)
+                .build();
     }
 
     public List<ResumeResponse> searchResumesByUserName(String userName) {
         List<Resume> resumes = resumeRepository.findByUsername(userName);
         return resumes.stream()
-                .map(resume -> new ResumeResponse(resume.getId(), resume.getUsername(), resume.getResumeName(), resume.getUrl()))
+                .map(ResumeResponse::of)
                 .toList();
     }
 
@@ -90,7 +98,7 @@ public class ResumeService {
         Specification<Resume> spec = ResumeSpecification.search(req);
         Page<Resume> allActiveResumes = getResumeRepository.findAllActiveResumes(spec, pageable);
         return allActiveResumes.stream()
-                .map(ResumeResponse::from)
+                .map(ResumeResponse::of)
                 .collect(Collectors.toList());
     }
 
@@ -100,6 +108,10 @@ public class ResumeService {
                 .map(ResumePageElement::of)
                 .toList();
 
-        return ResumePageResponse.from(elements, resumes);
+        return ResumePageResponse.builder()
+                .elementList(elements)
+                .totalPage(resumes.getTotalPages())
+                .currentPage(resumes.getNumber())
+                .build();
     }
 }

--- a/backend/src/main/java/com/techeer/backend/api/resume/service/ResumeService.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/service/ResumeService.java
@@ -3,6 +3,7 @@ package com.techeer.backend.api.resume.service;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.techeer.backend.api.feedback.domain.Feedback;
+import com.techeer.backend.api.feedback.dto.Response.FeedbackResponse;
 import com.techeer.backend.api.feedback.repository.FeedbackRepository;
 import com.techeer.backend.api.resume.domain.Resume;
 import com.techeer.backend.api.resume.dto.request.CreateResumeRequest;
@@ -71,9 +72,9 @@ public class ResumeService {
 
         // 이력서의 피드백 찾기
         List<Feedback> feedbacks = feedbackRepository.findAllByResumeId(resumeId);
-
+        List<FeedbackResponse> feedbackList= feedbacks.stream().map(FeedbackResponse::of).toList();
         // FetchResumeContentResponse 객체 생성 후 반환
-        return FetchResumeContentResponse.from(resume, feedbacks);
+        return FetchResumeContentResponse.from(resume, feedbackList);
     }
 
     public List<ResumeResponse> searchResumesByUserName(String userName) {

--- a/backend/src/main/java/com/techeer/backend/api/user/dto/request/UserRegisterRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/dto/request/UserRegisterRequest.java
@@ -20,5 +20,4 @@ public class UserRegisterRequest {
     @NotBlank
     private String email;
 
-    //public User toEntity() {return new User(this);}
 }


### PR DESCRIPTION
## 변경 사항
피드백에 id, resumeid, 내용, 좌표만 나온다.
마찬가지로 이력서 개별조회 할때 위에 있는 내용만 전달한다.


## 테스트 결과 (테스트를 했으면)
<img width="1347" alt="스크린샷 2024-10-01 오후 4 43 17" src="https://github.com/user-attachments/assets/577e8818-065e-411d-bf80-b62221843863">
<img width="1342" alt="스크린샷 2024-10-01 오후 4 42 54" src="https://github.com/user-attachments/assets/4f6ac8f6-5850-4116-a49e-e33c7ba16be8">


## +α Checklist
- [x] 자바 코드 컨벤션을 지키면서 프로그래밍했는가?
- [x] 한 메서드에 오직 한 단계의 들여쓰기(indent)만 허용했는가?
- [ ] else 예약어를 쓰지 않았는가?
- [ ] 모든 원시값과 문자열을 포장했는가?
- [ ] 콜렉션에 대해 일급 콜렉션을 적용했는가?
- [ ] 3개 이상의 인스턴스 변수를 가진 클래스를 구현하지 않았는가? (가능하면 인스턴스 변수의 수를 줄이기 위해 노력한다.)
- [x] getter/setter 없이 구현했는가? (단, DTO는 허용한다.)
- [ ] 메소드의 인자 수를 제한했는가? (4개 이상의 인자는 허용하지 않는다. 3개도 가능하면 줄이기 위해 노력해 본다.)
- [ ] 코드 한 줄에 점(.)을 하나만 허용했는가?
- [ ] 메소드가 한가지 일만 담당하도록 구현했는가?
- [ ] 클래스를 작게 유지하기 위해 노력했는가?