### PR TITLE
validation 에러에 대한 설명 구체화 + 서버에러에 대해 500 에러

### DIFF
--- a/backend/src/main/java/com/techeer/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/backend/global/error/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     // global
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G001", "서버 오류"),
     NOT_FOUND(HttpStatus.NOT_FOUND, "G002", "오브젝트를 찾을 수 없다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "G003", "유효하지 않은 값"),
 
     // Resume
     RESUME_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "이력서를 찾을 수 없음"),

--- a/backend/src/main/java/com/techeer/backend/global/error/ErrorResponse.java
+++ b/backend/src/main/java/com/techeer/backend/global/error/ErrorResponse.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,7 +15,7 @@ public class ErrorResponse {
     private HttpStatus httpStatus;
     private String code;
     private String errorMessage;
-    private List<FieldError> errors =null;
+    private List<FieldError> errors =new ArrayList<>();
 
 
     public ErrorResponse(HttpStatus status, String s) {

--- a/backend/src/main/java/com/techeer/backend/global/error/ErrorResponse.java
+++ b/backend/src/main/java/com/techeer/backend/global/error/ErrorResponse.java
@@ -1,13 +1,22 @@
 package com.techeer.backend.global.error;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class ErrorResponse {
     private HttpStatus httpStatus;
     private String code;
     private String errorMessage;
+    private List<FieldError> errors =null;
+
 
     public ErrorResponse(HttpStatus status, String s) {
         this.errorMessage = s;
@@ -18,5 +27,43 @@ public class ErrorResponse {
         this.errorMessage = code.getMessage();
         this.httpStatus = code.getStatus();
         this.code = code.getCode();
+    }
+
+    public ErrorResponse(ErrorCode code, List<FieldError> fieldErrors) {
+        this.httpStatus = code.getStatus();
+        this.code = code.getCode();
+        this.errorMessage = code.getMessage();
+        this.errors = fieldErrors;
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+        return new ErrorResponse(code, FieldError.of(bindingResult));
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+
+        public FieldError(final String field, final String value, final String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        private static List<FieldError> of(final BindingResult bindingResult) {
+            final List<org.springframework.validation.FieldError> fieldErrors =
+                    bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(
+                            error ->
+                                    new FieldError(
+                                            error.getField(),
+                                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
     }
 }

--- a/backend/src/main/java/com/techeer/backend/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/techeer/backend/global/error/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.techeer.backend.global.error.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,7 +15,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error(e.getMessage(), e);
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
         return new ResponseEntity<>(errorResponse, errorResponse.getHttpStatus());
     }
 
@@ -24,5 +25,11 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = new ErrorResponse(errorCode);
         return new ResponseEntity<>(errorResponse, errorCode.getStatus());
     }
-
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e) {
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_REQUEST, e.getBindingResult());
+        log.warn(e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
 }


### PR DESCRIPTION
## 변경 사항
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

서버 에러에 대해 500 호출 하도록

validation error에 대한 상세 에러 추가


## 테스트 결과 (테스트를 했으면)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
<img width="570" alt="image" src="https://github.com/user-attachments/assets/4ebf2f0d-eaeb-4c5f-a47f-d3981d716749">


## +α Checklist
- [ ] 자바 코드 컨벤션을 지키면서 프로그래밍했는가?
- [ ] 한 메서드에 오직 한 단계의 들여쓰기(indent)만 허용했는가?
- [ ] else 예약어를 쓰지 않았는가?
- [ ] 모든 원시값과 문자열을 포장했는가?
- [ ] 콜렉션에 대해 일급 콜렉션을 적용했는가?
- [ ] 3개 이상의 인스턴스 변수를 가진 클래스를 구현하지 않았는가? (가능하면 인스턴스 변수의 수를 줄이기 위해 노력한다.)
- [ ] getter/setter 없이 구현했는가? (단, DTO는 허용한다.)
- [ ] 메소드의 인자 수를 제한했는가? (4개 이상의 인자는 허용하지 않는다. 3개도 가능하면 줄이기 위해 노력해 본다.)
- [ ] 코드 한 줄에 점(.)을 하나만 허용했는가?
- [ ] 메소드가 한가지 일만 담당하도록 구현했는가?
- [ ] 클래스를 작게 유지하기 위해 노력했는가?