### PR TITLE
[feat] 권한 설정 준비 완료

### DIFF
--- a/backend/src/main/java/com/techeer/backend/api/user/controller/UserController.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/controller/UserController.java
@@ -26,8 +26,8 @@ public class UserController {
 
     @Operation(summary = "추가정보 입력")
     @PostMapping("/users")
-    public ResponseEntity<SuccessResponse> signupUser(@RequestBody @Valid SignUpRequest signUpReq) {
-        userService.signup(signUpReq);
+    public ResponseEntity<SuccessResponse> signupUser(@RequestBody @Valid SignUpRequest req) {
+        userService.signup(req);
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/com/techeer/backend/api/user/converter/UserConverter.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/converter/UserConverter.java
@@ -1,0 +1,14 @@
+package com.techeer.backend.api.user.converter;
+
+import com.techeer.backend.api.user.domain.Role;
+import com.techeer.backend.api.user.domain.User;
+
+public class UserConverter {
+    public static User fromSignUp(String email, String refreshToken, Role role){
+        return User.builder()
+                .email(email)
+                .refreshToken(refreshToken)
+                .role(role)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/techeer/backend/api/user/domain/User.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/domain/User.java
@@ -32,26 +32,29 @@ public class User extends BaseEntity {
 //    @Column(name = "profile_image")
 //    private String profileImage;
 
-//    @Enumerated(EnumType.STRING)
-//    @Column(name = "role")
-//    private Role role;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role")
+    private Role role;
 
     @Builder
-    public User(String email, String refreshToken){
+    public User(String email, String refreshToken, Role role) {
         this.email = email;
         this.username = null;
         this.refreshToken = refreshToken;
+        this.role = role;
     }
 
-    public static User fromSignup(String email, String refreshToken){
-        return User.builder()
-                .email(email)
-                .refreshToken(refreshToken)
-                .build();
-    }
+//    public static User fromSignup(String email, String refreshToken){
+//        return User.builder()
+//                .email(email)
+//                .refreshToken(refreshToken)
+//                .build();
+//    }
 
-    public void signupOf(SignUpRequest req){
+
+    public void updateUser(SignUpRequest req){
         this.username = req.getUsername();
+        this.role = req.getRole();
     }
 
     public void onLogout() {

--- a/backend/src/main/java/com/techeer/backend/api/user/dto/request/SignUpRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/dto/request/SignUpRequest.java
@@ -2,7 +2,9 @@ package com.techeer.backend.api.user.dto.request;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.techeer.backend.api.user.domain.Role;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
@@ -12,6 +14,7 @@ public class SignUpRequest {
     @NotBlank(message = "이름 입력하세요")
     private String username;
 
-
+    @NotNull(message = "권한을 입력하세요 (REGULAR, TECHEER, ADMIN)")
+    private Role role;
 }
 

--- a/backend/src/main/java/com/techeer/backend/api/user/service/UserService.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/service/UserService.java
@@ -30,8 +30,8 @@ public class UserService {
 
     public void signup(SignUpRequest signUpReq) {
         User user = this.getLoginUser();
-        if (userRepository.findByEmail(user.getEmail()).isEmpty()) {
-            user.signupOf(signUpReq);
+        if (userRepository.findByEmail(user.getEmail()).isPresent()) {
+            user.updateUser(signUpReq);
             userRepository.save(user);
         }
     }

--- a/backend/src/main/java/com/techeer/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/techeer/backend/global/config/SecurityConfig.java
@@ -65,6 +65,11 @@ public class SecurityConfig {
 			.sessionManagement(configurer -> configurer
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			)
+//			.authorizeHttpRequests(requests -> requests
+//					.requestMatchers("/api/v1/resumes/search").hasRole("ADMIN") // resume
+//					.requestMatchers("/api/v1/resumes/**").hasAnyRole("ADMIN","REGULAR") // resume
+//					.anyRequest().permitAll()
+//			)
 			.authorizeHttpRequests(requests ->
 					requests.anyRequest().permitAll() // 모든 요청을 모든 사용자에게 허용
 			)

--- a/backend/src/main/java/com/techeer/backend/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/techeer/backend/global/jwt/JwtAuthenticationFilter.java
@@ -76,7 +76,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         UserDetails userDetailsUser = org.springframework.security.core.userdetails.User.builder()
                 .username(user.getEmail())
                 .password("Google")
-                //.roles(user.getRole().name())
+                .roles(user.getRole().name())
                 .build();
 
         Authentication authentication =

--- a/backend/src/main/java/com/techeer/backend/global/oauth/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/techeer/backend/global/oauth/OAuth2LoginSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.techeer.backend.global.oauth;
 
+import com.techeer.backend.api.user.converter.UserConverter;
 import com.techeer.backend.api.user.domain.Role;
 import com.techeer.backend.api.user.domain.User;
 import com.techeer.backend.api.user.repository.UserRepository;
@@ -53,8 +54,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                         }
                     }, () -> {
                         // 사용자가 존재하지 않을 경우 (GUEST)
-
-                        User newUser = User.fromSignup(oAuth2User.getEmail(),refreshToken);// 초기 RefreshToken 설정
+                        // todo: 지금은 바로 REGULAR 저장 하지만 나중에 수정
+                        User newUser = UserConverter.fromSignUp(oAuth2User.getEmail(),refreshToken,Role.REGULAR);// 초기 RefreshToken 설정
                         userRepository.save(newUser); // 새로운 사용자 저장
 
                         response.setContentType("application/json");


### PR DESCRIPTION
## 변경 사항
로그인 권한 설정 완료
기능은 주석처리 해놨음
**이후 권한 설정 필요하면 바로 가능** -> URL만 추가하면 됨

## 테스트 결과 (테스트를 했으면)
아래 테스트를 해보고 싶으면 SecurityConfig에 아래 주석부분을 풀어주고

>  .authorizeHttpRequests(requests ->
> 					requests.anyRequest().permitAll() // 모든 요청을 모든 사용자에게 허용
> 			) 

여기러 주석 처리해주면 됩니다.
<img width="901" alt="스크린샷 2024-10-25 오후 11 45 39" src="https://github.com/user-attachments/assets/0979250f-3370-42bd-b860-c92709ed8bec">



1. 로그인
여기서 로그인 과정 확인 ->https://github.com/Techeer-blabla/techeer-resume/pull/99

처음에는 이름은 NULL, Role은 REGULAR로 되어있습니다. 
<img width="920" alt="스크린샷 2024-10-25 오후 11 16 49" src="https://github.com/user-attachments/assets/1f80c1f0-e48e-4e5d-a41d-25966d99bb5c">

2. REGULAR 권한으로 접근
(임시) /api/v1/resumes/** 는 "ADMIN","REGULAR" 접근 가능
<img width="978" alt="스크린샷 2024-10-25 오후 11 36 00" src="https://github.com/user-attachments/assets/7f92e9de-31e6-4cdd-beda-ceb708a26fe0">

(임시) /api/v1/resumes/search 는 "ADMIN" 만 접근가능
**403 권한 에러** 
<img width="955" alt="스크린샷 2024-10-25 오후 11 40 05" src="https://github.com/user-attachments/assets/946375a8-d312-4f7b-b8d6-1f11e0e5204e">

3. ADMIN권한으로 변경
user는 로그인 후 계정 생성 단계 사용할 API
지금은 권한 변경으로 보면 좋을 것 같다.
<img width="1001" alt="스크린샷 2024-10-25 오후 11 41 28" src="https://github.com/user-attachments/assets/aeb00e6a-a8a9-462c-9501-429f2cce50f5">

4. ADMIN권한으로 접근 
정상접근 가능
<img width="1021" alt="스크린샷 2024-10-25 오후 11 43 22" src="https://github.com/user-attachments/assets/8c96b3ab-f54b-4f95-ba81-3b77443c7648">


## +α Checklist
- [ ] 자바 코드 컨벤션을 지키면서 프로그래밍했는가?
- [ ] 한 메서드에 오직 한 단계의 들여쓰기(indent)만 허용했는가?
- [ ] else 예약어를 쓰지 않았는가?
- [ ] 모든 원시값과 문자열을 포장했는가?
- [ ] 콜렉션에 대해 일급 콜렉션을 적용했는가?
- [ ] 3개 이상의 인스턴스 변수를 가진 클래스를 구현하지 않았는가? (가능하면 인스턴스 변수의 수를 줄이기 위해 노력한다.)
- [ ] getter/setter 없이 구현했는가? (단, DTO는 허용한다.)
- [ ] 메소드의 인자 수를 제한했는가? (4개 이상의 인자는 허용하지 않는다. 3개도 가능하면 줄이기 위해 노력해 본다.)
- [ ] 코드 한 줄에 점(.)을 하나만 허용했는가?
- [ ] 메소드가 한가지 일만 담당하도록 구현했는가?
- [ ] 클래스를 작게 유지하기 위해 노력했는가?