### PR TITLE
[refactor] 피드백, ai피드백 조회 통합 및 반환값 통일

### DIFF
--- a/backend/src/main/java/com/techeer/backend/api/aifeedback/repository/AIFeedbackRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/aifeedback/repository/AIFeedbackRepository.java
@@ -1,9 +1,11 @@
 package com.techeer.backend.api.aifeedback.repository;
 
 import com.techeer.backend.api.aifeedback.domain.AIFeedback;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AIFeedbackRepository extends JpaRepository<AIFeedback, Long> {
+    Optional<AIFeedback> findByResumeId(Long resumeId);
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/controller/FeedbackController.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/controller/FeedbackController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -53,7 +52,7 @@ public class FeedbackController {
 
     @Operation(summary = "피드백 삭제")
     @DeleteMapping("/{resume_id}/feedbacks/{feedback_id}")
-    public ResponseEntity<CommonResponse<Void>> deleteFeedback(
+    public CommonResponse<Void> deleteFeedback(
             @PathVariable("resume_id") Long resumeId,
             @PathVariable("feedback_id") Long feedbackId) {
 
@@ -61,7 +60,6 @@ public class FeedbackController {
 
         feedbackService.deleteFeedbackById(resumeId, feedbackId);
 
-        return ResponseEntity.status(SuccessStatus.NO_CONTENT.getHttpStatus())
-                .body(CommonResponse.of(SuccessStatus.NO_CONTENT, null));
+        return CommonResponse.of(SuccessStatus.NO_CONTENT, null);
     }
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/controller/FeedbackController.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/controller/FeedbackController.java
@@ -4,12 +4,13 @@ import com.techeer.backend.api.feedback.dto.AllFeedbackResponse;
 import com.techeer.backend.api.feedback.dto.FeedbackCreateRequest;
 import com.techeer.backend.api.feedback.dto.FeedbackResponse;
 import com.techeer.backend.api.feedback.service.FeedbackService;
+import com.techeer.backend.global.common.response.CommonResponse;
+import com.techeer.backend.global.success.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,37 +24,36 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "이력서 피드백 등록 API", description = "Feedback API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/resumes/") // 공통 api
+@RequestMapping("/api/v1/resumes/")
 public class FeedbackController {
 
     private final FeedbackService feedbackService;
 
     @Operation(summary = "피드백 등록", description = "원하는 위치에 피드백을 작성합니다.")
     @PostMapping("/{resume_id}/feedbacks")
-    public ResponseEntity<FeedbackResponse> createFeedback(
+    public CommonResponse<FeedbackResponse> createFeedback(
             @PathVariable("resume_id") Long resumeId,
             @Valid @RequestBody FeedbackCreateRequest feedbackRequest) {
 
         log.info("이력서 ID: {} 에 대한 피드백 생성 요청", resumeId);
 
-        // 피드백 생성 후 응답 생성
         FeedbackResponse feedbackResponse = feedbackService.createFeedback(resumeId, feedbackRequest);
 
         log.info("피드백 생성 완료: {}", feedbackResponse);
 
-        return new ResponseEntity<>(feedbackResponse, HttpStatus.CREATED);
+        return CommonResponse.of(SuccessStatus.CREATED, feedbackResponse);
     }
 
-    @Operation(summary = "AI 피드백, 일반 피드백 조회", description = "해당 이력서에 대한 ai 피드백과 일반 피드백 조회")
+    @Operation(summary = "AI 피드백, 일반 피드백 조회", description = "해당 이력서에 대한 AI 피드백과 일반 피드백 조회")
     @GetMapping("/{resume_id}/feedbacks")
-    public ResponseEntity<AllFeedbackResponse> getFeedbackWithAIFeedback(@PathVariable("resume_id") Long resumeId) {
-        AllFeedbackResponse response = feedbackService.getFeedbackwithAIFeedback(resumeId);
-        return ResponseEntity.ok(response);
+    public CommonResponse<AllFeedbackResponse> getFeedbackWithAIFeedback(@PathVariable("resume_id") Long resumeId) {
+        AllFeedbackResponse response = feedbackService.getFeedbackWithAIFeedback(resumeId);
+        return CommonResponse.of(SuccessStatus.FEEDBACK_FETCH_OK, response);
     }
 
     @Operation(summary = "피드백 삭제")
     @DeleteMapping("/{resume_id}/feedbacks/{feedback_id}")
-    public ResponseEntity<Void> deleteFeedback(
+    public ResponseEntity<CommonResponse<Void>> deleteFeedback(
             @PathVariable("resume_id") Long resumeId,
             @PathVariable("feedback_id") Long feedbackId) {
 
@@ -61,6 +61,7 @@ public class FeedbackController {
 
         feedbackService.deleteFeedbackById(resumeId, feedbackId);
 
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        return ResponseEntity.status(SuccessStatus.NO_CONTENT.getHttpStatus())
+                .body(CommonResponse.of(SuccessStatus.NO_CONTENT, null));
     }
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/controller/FeedbackController.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/controller/FeedbackController.java
@@ -1,23 +1,23 @@
 package com.techeer.backend.api.feedback.controller;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
+import com.techeer.backend.api.feedback.dto.AllFeedbackResponse;
 import com.techeer.backend.api.feedback.dto.FeedbackCreateRequest;
 import com.techeer.backend.api.feedback.dto.FeedbackResponse;
 import com.techeer.backend.api.feedback.service.FeedbackService;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @Tag(name = "이력서 피드백 등록 API", description = "Feedback API")
@@ -26,34 +26,41 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/v1/resumes/") // 공통 api
 public class FeedbackController {
 
-	private final FeedbackService feedbackService;
+    private final FeedbackService feedbackService;
 
-	@Operation(summary = "피드백 등록", description = "원하는 위치에 피드백을 작성합니다.")
-	@PostMapping("/{resume_id}/feedbacks")
-	public ResponseEntity<FeedbackResponse> createFeedback(
-		@PathVariable("resume_id") Long resumeId,
-		@Valid @RequestBody FeedbackCreateRequest feedbackRequest) {
+    @Operation(summary = "피드백 등록", description = "원하는 위치에 피드백을 작성합니다.")
+    @PostMapping("/{resume_id}/feedbacks")
+    public ResponseEntity<FeedbackResponse> createFeedback(
+            @PathVariable("resume_id") Long resumeId,
+            @Valid @RequestBody FeedbackCreateRequest feedbackRequest) {
 
-		log.info("이력서 ID: {} 에 대한 피드백 생성 요청", resumeId);
+        log.info("이력서 ID: {} 에 대한 피드백 생성 요청", resumeId);
 
-		// 피드백 생성 후 응답 생성
-		FeedbackResponse feedbackResponse = feedbackService.createFeedback(resumeId, feedbackRequest);
+        // 피드백 생성 후 응답 생성
+        FeedbackResponse feedbackResponse = feedbackService.createFeedback(resumeId, feedbackRequest);
 
-		log.info("피드백 생성 완료: {}", feedbackResponse);
+        log.info("피드백 생성 완료: {}", feedbackResponse);
 
-		return new ResponseEntity<>(feedbackResponse, HttpStatus.CREATED);
-	}
+        return new ResponseEntity<>(feedbackResponse, HttpStatus.CREATED);
+    }
 
-	@Operation(summary = "피드백 삭제")
-	@DeleteMapping("/{resume_id}/feedbacks/{feedback_id}")
-	public ResponseEntity<Void> deleteFeedback(
-		@PathVariable("resume_id") Long resumeId,
-		@PathVariable("feedback_id") Long feedbackId) {
+    @Operation(summary = "AI 피드백, 일반 피드백 조회", description = "해당 이력서에 대한 ai 피드백과 일반 피드백 조회")
+    @GetMapping("/{resume_id}/feedbacks")
+    public ResponseEntity<AllFeedbackResponse> getFeedbackWithAIFeedback(@PathVariable("resume_id") Long resumeId) {
+        AllFeedbackResponse response = feedbackService.getFeedbackwithAIFeedback(resumeId);
+        return ResponseEntity.ok(response);
+    }
 
-		log.info("이력서 ID: {}, 피드백 ID: {} 에 대한 삭제 요청", resumeId, feedbackId);
+    @Operation(summary = "피드백 삭제")
+    @DeleteMapping("/{resume_id}/feedbacks/{feedback_id}")
+    public ResponseEntity<Void> deleteFeedback(
+            @PathVariable("resume_id") Long resumeId,
+            @PathVariable("feedback_id") Long feedbackId) {
 
-		feedbackService.deleteFeedbackById(resumeId, feedbackId);
+        log.info("이력서 ID: {}, 피드백 ID: {} 에 대한 삭제 요청", resumeId, feedbackId);
 
-		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-	}
+        feedbackService.deleteFeedbackById(resumeId, feedbackId);
+
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/converter/FeedbackConverter.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/converter/FeedbackConverter.java
@@ -23,7 +23,7 @@ public class FeedbackConverter {
 
     public static AllFeedbackResponse toAllFeedbackResponse(List<Feedback> feedbacks, AIFeedback aiFeedback) {
         return AllFeedbackResponse.builder()
-                .feedbacks(convertFeedbacksToResponses(feedbacks))
+                .feedbackResponses(convertFeedbacksToResponses(feedbacks))
                 .aiFeedbackContent(Optional.ofNullable(aiFeedback).map(AIFeedback::getFeedback).orElse(null))
                 .aiFeedbackId(Optional.ofNullable(aiFeedback).map(AIFeedback::getId).orElse(null))
                 .build();

--- a/backend/src/main/java/com/techeer/backend/api/feedback/converter/FeedbackConverter.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/converter/FeedbackConverter.java
@@ -4,6 +4,9 @@ import com.techeer.backend.api.aifeedback.domain.AIFeedback;
 import com.techeer.backend.api.feedback.domain.Feedback;
 import com.techeer.backend.api.feedback.dto.AllFeedbackResponse;
 import com.techeer.backend.api.feedback.dto.FeedbackResponse;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class FeedbackConverter {
 
@@ -18,16 +21,24 @@ public class FeedbackConverter {
                 .build();
     }
 
-    public static AllFeedbackResponse toAllFeedbackResponse(Feedback feedback, AIFeedback aiFeedback) {
+    public static AllFeedbackResponse toAllFeedbackResponse(List<Feedback> feedbacks, AIFeedback aiFeedback) {
         return AllFeedbackResponse.builder()
-                .feedbackId(feedback.getId())
-                .resumeId(feedback.getResume().getId())
-                .content(feedback.getContent())
-                .xCoordinate(feedback.getXCoordinate())
-                .yCoordinate(feedback.getYCoordinate())
-                .pageNumber(feedback.getPageNumber())
-                .aiFeedbackContent(aiFeedback.getFeedback()) // AI 피드백 내용
-                .aiFeedbackId(aiFeedback.getId()) // AI 피드백 ID
+                .feedbacks(convertFeedbacksToResponses(feedbacks))
+                .aiFeedbackContent(Optional.ofNullable(aiFeedback).map(AIFeedback::getFeedback).orElse(null))
+                .aiFeedbackId(Optional.ofNullable(aiFeedback).map(AIFeedback::getId).orElse(null))
                 .build();
+    }
+
+    private static List<FeedbackResponse> convertFeedbacksToResponses(List<Feedback> feedbacks) {
+        return feedbacks.stream()
+                .map(feedback -> FeedbackResponse.builder()
+                        .feedbackId(feedback.getId())
+                        .resumeId(feedback.getResume().getId())
+                        .content(feedback.getContent())
+                        .xCoordinate(feedback.getXCoordinate())
+                        .yCoordinate(feedback.getYCoordinate())
+                        .pageNumber(feedback.getPageNumber())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/converter/FeedbackConverter.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/converter/FeedbackConverter.java
@@ -1,6 +1,8 @@
 package com.techeer.backend.api.feedback.converter;
 
+import com.techeer.backend.api.aifeedback.domain.AIFeedback;
 import com.techeer.backend.api.feedback.domain.Feedback;
+import com.techeer.backend.api.feedback.dto.AllFeedbackResponse;
 import com.techeer.backend.api.feedback.dto.FeedbackResponse;
 
 public class FeedbackConverter {
@@ -8,10 +10,24 @@ public class FeedbackConverter {
     public static FeedbackResponse toFeedbackResponse(Feedback feedback) {
         return FeedbackResponse.builder()
                 .feedbackId(feedback.getId())
+                .resumeId(feedback.getResume().getId())
+                .content(feedback.getContent())
+                .xCoordinate(feedback.getXCoordinate())
+                .yCoordinate(feedback.getYCoordinate())
+                .pageNumber(feedback.getPageNumber())// AI 피드백 내용 포함
+                .build();
+    }
+
+    public static AllFeedbackResponse toAllFeedbackResponse(Feedback feedback, AIFeedback aiFeedback) {
+        return AllFeedbackResponse.builder()
+                .feedbackId(feedback.getId())
+                .resumeId(feedback.getResume().getId())
                 .content(feedback.getContent())
                 .xCoordinate(feedback.getXCoordinate())
                 .yCoordinate(feedback.getYCoordinate())
                 .pageNumber(feedback.getPageNumber())
+                .aiFeedbackContent(aiFeedback.getFeedback()) // AI 피드백 내용
+                .aiFeedbackId(aiFeedback.getId()) // AI 피드백 ID
                 .build();
     }
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/dto/AllFeedbackResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/dto/AllFeedbackResponse.java
@@ -1,5 +1,6 @@
 package com.techeer.backend.api.feedback.dto;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,13 +11,7 @@ import lombok.ToString;
 @Getter
 @ToString
 public class AllFeedbackResponse {
-    private final Long feedbackId;
-    private final Long resumeId;
-    private final String content;
-    private final Double xCoordinate;
-    private final Double yCoordinate;
-    private final int pageNumber;
-
+    private final List<FeedbackResponse> feedbacks; // 여러 개의 피드백을 리스트로 포함
     private final String aiFeedbackContent;
     private final Long aiFeedbackId;
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/dto/AllFeedbackResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/dto/AllFeedbackResponse.java
@@ -11,7 +11,7 @@ import lombok.ToString;
 @Getter
 @ToString
 public class AllFeedbackResponse {
-    private final List<FeedbackResponse> feedbacks; // 여러 개의 피드백을 리스트로 포함
+    private final List<FeedbackResponse> feedbackResponses; // 여러 개의 피드백을 리스트로 포함
     private final String aiFeedbackContent;
     private final Long aiFeedbackId;
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/dto/AllFeedbackResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/dto/AllFeedbackResponse.java
@@ -5,16 +5,18 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
-@Getter
 @Builder
 @AllArgsConstructor
+@Getter
 @ToString
-public class FeedbackResponse {
+public class AllFeedbackResponse {
     private final Long feedbackId;
     private final Long resumeId;
     private final String content;
     private final Double xCoordinate;
     private final Double yCoordinate;
     private final int pageNumber;
+
     private final String aiFeedbackContent;
+    private final Long aiFeedbackId;
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/dto/FeedbackResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/dto/FeedbackResponse.java
@@ -16,5 +16,4 @@ public class FeedbackResponse {
     private final Double xCoordinate;
     private final Double yCoordinate;
     private final int pageNumber;
-    private final String aiFeedbackContent;
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/repository/FeedbackRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/repository/FeedbackRepository.java
@@ -1,14 +1,16 @@
 package com.techeer.backend.api.feedback.repository;
 
 import com.techeer.backend.api.feedback.domain.Feedback;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     Optional<Feedback> findByIdAndResumeId(Long id, Long resumeId);
+
     List<Feedback> findAllByResumeId(Long resumeId);
+
+    Optional<Feedback> findByResumeId(Long resumeId);
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/service/FeedbackService.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/service/FeedbackService.java
@@ -10,7 +10,9 @@ import com.techeer.backend.api.feedback.dto.FeedbackResponse;
 import com.techeer.backend.api.feedback.repository.FeedbackRepository;
 import com.techeer.backend.api.resume.domain.Resume;
 import com.techeer.backend.api.resume.repository.ResumeRepository;
-import jakarta.persistence.EntityNotFoundException;
+import com.techeer.backend.global.error.ErrorStatus;
+import com.techeer.backend.global.error.exception.BusinessException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,11 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class FeedbackService {
-
-    private static final String RESUME_NOT_FOUND_MESSAGE = "이력서를 찾을 수 없습니다.";
-    private static final String FEEDBACK_NOT_FOUND_MESSAGE = "피드백을 찾을 수 없습니다.";
-    private static final String INVALID_FEEDBACK_FOR_RESUME_MESSAGE = "이력서에 해당하는 피드백이 아닙니다";
-
     private final FeedbackRepository feedbackRepository;
     private final ResumeRepository resumeRepository;
     private final AIFeedbackRepository aiFeedbackRepository;
@@ -32,49 +29,44 @@ public class FeedbackService {
     @Transactional
     public FeedbackResponse createFeedback(Long resumeId, FeedbackCreateRequest feedbackCreateRequest) {
         Resume resume = resumeRepository.findByIdAndDeletedAtIsNull(resumeId)
-                .orElseThrow(() -> new EntityNotFoundException(RESUME_NOT_FOUND_MESSAGE));
-
-        log.info("이력서 ID: {} 에 피드백 생성 중", resumeId);
+                .orElseThrow(() -> new BusinessException(ErrorStatus.RESUME_NOT_FOUND));
 
         Feedback feedback = Feedback.of(resume, feedbackCreateRequest);
         feedbackRepository.save(feedback);
 
-        log.info("피드백 생성 완료: {}", feedback);
         return FeedbackConverter.toFeedbackResponse(feedback);
     }
 
     @Transactional
     public void deleteFeedbackById(Long resumeId, Long feedbackId) {
-
-        // 이력서가 존재하는지 먼저 확인
         Resume resume = resumeRepository.findById(resumeId)
-                .orElseThrow(() -> new EntityNotFoundException(RESUME_NOT_FOUND_MESSAGE));
+                .orElseThrow(() -> new BusinessException(ErrorStatus.RESUME_NOT_FOUND));
 
-        // 피드백이 존재하고, 해당 이력서와 연관되어 있는지 확인
         Feedback feedback = feedbackRepository.findById(feedbackId)
-                .orElseThrow(() -> new IllegalArgumentException(FEEDBACK_NOT_FOUND_MESSAGE));
+                .orElseThrow(() -> new BusinessException(ErrorStatus.FEEDBACK_NOT_FOUND));
 
-        // 피드백이 이력서와 연관되어 있는지 확인
         if (!feedback.getResume().getId().equals(resume.getId())) {
-            throw new IllegalArgumentException(String.format(INVALID_FEEDBACK_FOR_RESUME_MESSAGE));
+            throw new BusinessException(ErrorStatus.INVALID_FEEDBACK_FOR_RESUME);
         }
 
         log.info("피드백 삭제 중: 피드백 ID {} (이력서 ID {})", feedbackId, resumeId);
 
-        // 피드백 삭제
         feedbackRepository.delete(feedback);
     }
 
     @Transactional(readOnly = true)
-    public AllFeedbackResponse getFeedbackwithAIFeedback(Long resumeId) {
-        // 일반 피드백 조회
-        Feedback feedback = feedbackRepository.findByResumeId(resumeId)
-                .orElseThrow(() -> new EntityNotFoundException("일반 피드백을 찾을 수 없습니다."));
+    public AllFeedbackResponse getFeedbackWithAIFeedback(Long resumeId) {
+        // resumeId에 해당하는 모든 피드백 가져오기
+        List<Feedback> feedbacks = feedbackRepository.findAllByResumeId(resumeId);
+        if (feedbacks.isEmpty()) {
+            throw new BusinessException(ErrorStatus.FEEDBACK_NOT_FOUND);
+        }
 
-        // AI 피드백 조회
-        AIFeedback aiFeedback = aiFeedbackRepository.findByResumeId(resumeId)
-                .orElseThrow(() -> new EntityNotFoundException("AI 피드백을 찾을 수 없습니다."));
+        // resumeId에 해당하는 AI 피드백 가져오기 (없으면 null 설정)
+        AIFeedback aiFeedback = aiFeedbackRepository.findByResumeId(resumeId).orElse(null);
 
-        return FeedbackConverter.toAllFeedbackResponse(feedback, aiFeedback);
+        // FeedbackConverter에서 모든 피드백 리스트와 AI 피드백을 포함한 응답으로 변환
+        return FeedbackConverter.toAllFeedbackResponse(feedbacks, aiFeedback);
     }
+
 }

--- a/backend/src/main/java/com/techeer/backend/api/feedback/service/FeedbackService.java
+++ b/backend/src/main/java/com/techeer/backend/api/feedback/service/FeedbackService.java
@@ -1,7 +1,10 @@
 package com.techeer.backend.api.feedback.service;
 
+import com.techeer.backend.api.aifeedback.domain.AIFeedback;
+import com.techeer.backend.api.aifeedback.repository.AIFeedbackRepository;
 import com.techeer.backend.api.feedback.converter.FeedbackConverter;
 import com.techeer.backend.api.feedback.domain.Feedback;
+import com.techeer.backend.api.feedback.dto.AllFeedbackResponse;
 import com.techeer.backend.api.feedback.dto.FeedbackCreateRequest;
 import com.techeer.backend.api.feedback.dto.FeedbackResponse;
 import com.techeer.backend.api.feedback.repository.FeedbackRepository;
@@ -24,7 +27,7 @@ public class FeedbackService {
 
     private final FeedbackRepository feedbackRepository;
     private final ResumeRepository resumeRepository;
-    // private final FeedbackConverter feedbackConverter;
+    private final AIFeedbackRepository aiFeedbackRepository;
 
     @Transactional
     public FeedbackResponse createFeedback(Long resumeId, FeedbackCreateRequest feedbackCreateRequest) {
@@ -62,4 +65,16 @@ public class FeedbackService {
         feedbackRepository.delete(feedback);
     }
 
+    @Transactional(readOnly = true)
+    public AllFeedbackResponse getFeedbackwithAIFeedback(Long resumeId) {
+        // 일반 피드백 조회
+        Feedback feedback = feedbackRepository.findByResumeId(resumeId)
+                .orElseThrow(() -> new EntityNotFoundException("일반 피드백을 찾을 수 없습니다."));
+
+        // AI 피드백 조회
+        AIFeedback aiFeedback = aiFeedbackRepository.findByResumeId(resumeId)
+                .orElseThrow(() -> new EntityNotFoundException("AI 피드백을 찾을 수 없습니다."));
+
+        return FeedbackConverter.toAllFeedbackResponse(feedback, aiFeedback);
+    }
 }

--- a/backend/src/main/java/com/techeer/backend/global/error/ErrorStatus.java
+++ b/backend/src/main/java/com/techeer/backend/global/error/ErrorStatus.java
@@ -27,6 +27,13 @@ public enum ErrorStatus implements BaseStatus {
     RESUME_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "RESUME_PDf_502", "S3에 pdf를 올리는 것에 실패했습니다"),
 
     OPENAI_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "OPENAI_502", "OPENAI 서버에 연결하는 데 실패했습니다"),
+
+    // Feedback Error
+    FEEDBACK_NOT_FOUND(HttpStatus.NOT_FOUND, "FEEDBACK_404", "피드백을 찾을 수 없습니다."),
+    INVALID_FEEDBACK_FOR_RESUME(HttpStatus.BAD_REQUEST, "FEEDBACK_400", "이력서에 해당하는 피드백이 아닙니다."),
+
+    // AIFeedback Error
+    AIFEEDBACK_NOT_FOUND(HttpStatus.NOT_FOUND, "AIFEEDBACK_404", "AI 피드백을 찾을 수 없습니다."),
     ;
 
     // User Error

--- a/backend/src/main/java/com/techeer/backend/global/success/SuccessStatus.java
+++ b/backend/src/main/java/com/techeer/backend/global/success/SuccessStatus.java
@@ -18,7 +18,13 @@ public enum SuccessStatus implements BaseStatus {
     RESUME_CREATED(HttpStatus.CREATED, "RESUME_201", "이력서가 성공적으로 저장되었습니다"),
 
     // User  Success
-    USER_FETCH_OK(HttpStatus.OK, "USER_200", "유저 정보 조회 성공");
+    USER_FETCH_OK(HttpStatus.OK, "USER_200", "유저 정보 조회 성공"),
+
+    // Feedback Success
+    FEEDBACK_FETCH_OK(HttpStatus.OK, "FEEDBACK_200", "피드백 조회 성공"),
+
+    // AIFeedback Success
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 변경 사항
- 피드백 조회시 ai 피드백이 같이 조회되도록 수정 -> 이력서 당 ai 피드백은 한 개라고 생각해서 설계함
- response 값을 commonreponse, successreponse, errorstatus 적용



## 테스트 결과 (테스트를 했으면)
![image](https://github.com/user-attachments/assets/8f2aadcc-5804-432f-9132-558139146872)


## +α Checklist
- [ ] 자바 코드 컨벤션을 지키면서 프로그래밍했는가?
- [ ] 한 메서드에 오직 한 단계의 들여쓰기(indent)만 허용했는가?
- [ ] else 예약어를 쓰지 않았는가?
- [ ] 모든 원시값과 문자열을 포장했는가?
- [ ] 콜렉션에 대해 일급 콜렉션을 적용했는가?
- [ ] 3개 이상의 인스턴스 변수를 가진 클래스를 구현하지 않았는가? (가능하면 인스턴스 변수의 수를 줄이기 위해 노력한다.)
- [ ] getter/setter 없이 구현했는가? (단, DTO는 허용한다.)
- [ ] 메소드의 인자 수를 제한했는가? (4개 이상의 인자는 허용하지 않는다. 3개도 가능하면 줄이기 위해 노력해 본다.)
- [ ] 코드 한 줄에 점(.)을 하나만 허용했는가?
- [ ] 메소드가 한가지 일만 담당하도록 구현했는가?
- [ ] 클래스를 작게 유지하기 위해 노력했는가?