### PR TITLE
fix : 이력서 태그 조회 수정

### DIFF
--- a/backend/src/main/java/com/techeer/backend/api/resume/repository/GetResumeRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/repository/GetResumeRepository.java
@@ -1,6 +1,7 @@
 package com.techeer.backend.api.resume.repository;
 
 import com.techeer.backend.api.resume.domain.Resume;
+import com.techeer.backend.api.tag.position.Position;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,22 +13,21 @@ public interface GetResumeRepository extends JpaRepository<Resume, Long> {
 
     @Query(value = "SELECT DISTINCT r FROM Resume r " +
             "WHERE r.career BETWEEN :minCareer AND :maxCareer " +
+            "AND (:positions IS NULL OR r.position IN :positions) " +
             "AND (:techStackNames IS NULL OR EXISTS (" +
-            "SELECT 1 FROM ResumeTechStack rts " +
-            "WHERE rts.resume = r AND rts.techStack.name IN :techStackNames)) " +
+            "SELECT 1 FROM ResumeTechStack rts WHERE rts.resume = r AND rts.techStack.name IN :techStackNames)) " +
             "AND (:companyNames IS NULL OR EXISTS (" +
-            "SELECT 1 FROM ResumeCompany rc " +
-            "WHERE rc.resume = r AND rc.company.name IN :companyNames))",
+            "SELECT 1 FROM ResumeCompany rc WHERE rc.resume = r AND rc.company.name IN :companyNames))",
             countQuery = "SELECT COUNT(DISTINCT r) FROM Resume r " +
                     "WHERE r.career BETWEEN :minCareer AND :maxCareer " +
+                    "AND (:positions IS NULL OR r.position IN :positions) " +
                     "AND (:techStackNames IS NULL OR EXISTS (" +
-                    "SELECT 1 FROM ResumeTechStack rts " +
-                    "WHERE rts.resume = r AND rts.techStack.name IN :techStackNames)) " +
+                    "SELECT 1 FROM ResumeTechStack rts WHERE rts.resume = r AND rts.techStack.name IN :techStackNames)) " +
                     "AND (:companyNames IS NULL OR EXISTS (" +
-                    "SELECT 1 FROM ResumeCompany rc " +
-                    "WHERE rc.resume = r AND rc.company.name IN :companyNames))")
+                    "SELECT 1 FROM ResumeCompany rc WHERE rc.resume = r AND rc.company.name IN :companyNames))")
     Page<Resume> findResumesByCriteria(@Param("minCareer") int minCareer,
                                        @Param("maxCareer") int maxCareer,
+                                       @Param("positions") List<Position> positions,
                                        @Param("techStackNames") List<String> techStackNames,
                                        @Param("companyNames") List<String> companyNames,
                                        Pageable pageable);

--- a/backend/src/main/java/com/techeer/backend/api/resume/service/ResumeService.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/service/ResumeService.java
@@ -55,6 +55,7 @@ public class ResumeService {
         Page<Resume> resumesByCriteria = getResumeRepository.findResumesByCriteria(
                 req.getMinCareer(),
                 req.getMaxCareer(),
+                req.getPositions(),
                 techStackNames,
                 companyNames,
                 pageable


### PR DESCRIPTION
## 변경 사항
이력서 태그 조회가 정상 작동되도록 수정 완료


## 테스트 결과 (테스트를 했으면)
#### 조회한 태그 안에 해당 이력서가 들어갈 때
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/b8a989c2-6bdc-4346-83a0-2a0a9b2d3336">
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/3a0847fe-649b-43e4-b603-45cd5a020c64">

#### 조회한 태그 안에 해당 이력서가 포함되지 않을 때

- career min, max 내에 안 들어갈 때
<img width="1405" alt="image" src="https://github.com/user-attachments/assets/8a0e503a-bd73-4af3-aeaf-3d54010f34c3">
<br>

- position 안에 안 들어갈 때
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/d7601315-2fd4-44e9-851b-332544b1ca53">

<br>

- techStack안에 안 들어갈 때
<img width="1405" alt="image" src="https://github.com/user-attachments/assets/a0b631b9-bd2b-4d87-bde6-d2ca5315aefb">
<br>
