### PR TITLE
[feat] resume 테스트 코드 작성

### DIFF
--- a/backend/src/main/java/com/techeer/backend/api/resume/domain/Resume.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/domain/Resume.java
@@ -30,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 @Entity
 @Getter
 @Table(name = "Resume")
+@Builder
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Resume extends BaseEntity {

--- a/backend/src/main/java/com/techeer/backend/api/resume/dto/request/CreateResumeRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/dto/request/CreateResumeRequest.java
@@ -3,10 +3,12 @@ package com.techeer.backend.api.resume.dto.request;
 import com.techeer.backend.api.tag.position.Position;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
 
 //todo Getter 한번만 사용하기
 @Getter
+@Builder
 public class CreateResumeRequest {
 
     @NotNull(message = "position는 필수입니다.")

--- a/backend/src/test/java/com/techeer/backend/api/resume/controller/ResumeControllerTest.java
+++ b/backend/src/test/java/com/techeer/backend/api/resume/controller/ResumeControllerTest.java
@@ -1,0 +1,156 @@
+package com.techeer.backend.api.resume.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techeer.backend.api.feedback.service.FeedbackService;
+import com.techeer.backend.api.resume.domain.Resume;
+import com.techeer.backend.api.resume.dto.request.CreateResumeRequest;
+import com.techeer.backend.api.resume.dto.response.ResumeResponse;
+import com.techeer.backend.api.resume.service.ResumeService;
+import com.techeer.backend.api.resume.service.facade.ResumeCreateFacade;
+import com.techeer.backend.api.tag.position.Position;
+import com.techeer.backend.api.user.domain.Role;
+import com.techeer.backend.api.user.domain.SocialType;
+import com.techeer.backend.api.user.domain.User;
+import com.techeer.backend.api.user.service.UserService;
+import java.util.ArrayList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ResumeController.class)
+class ResumeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ResumeCreateFacade resumeCreateFacade;
+
+    @MockBean
+    private ResumeService resumeService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private FeedbackService feedbackService;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void resumeRegistration_WhenValidInput_ShouldReturnCreated() throws Exception {
+        // Arrange
+        CreateResumeRequest createResumeRequest = CreateResumeRequest.builder()
+                .techStackNames(Arrays.asList("Java", "Spring"))
+                .companyNames(Arrays.asList("CompanyA", "CompanyB"))
+                .position(Position.BACKEND) // Position enum 사용 시, 문자열 대신 enum 값 사용
+                .career(5)
+                .build();
+
+        String createResumeJson = objectMapper.writeValueAsString(createResumeRequest);
+
+        MockMultipartFile createResumeReq = new MockMultipartFile(
+                "createResumeReq",
+                "",
+                "application/json",
+                createResumeJson.getBytes()
+        );
+
+        MockMultipartFile resumeFile = new MockMultipartFile(
+                "resume_file",
+                "resume.pdf",
+                "application/pdf",
+                "Dummy PDF Content".getBytes()
+        );
+
+        // Act & Assert
+        mockMvc.perform(multipart("/api/v1/resumes")
+                        .file(createResumeReq)
+                        .file(resumeFile)
+                        .with(csrf())
+                        .with(oauth2Login())
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isCreated());
+
+        verify(resumeCreateFacade, times(1)).createResume(any(CreateResumeRequest.class), any());
+    }
+
+    @Test
+    @WithMockUser(username = "john_doe", roles = {"USER"})
+    void searchResumesByUserName_ShouldReturnListOfResumes() throws Exception {
+        // Arrange
+        String userName = "john_doe";
+
+        // User 객체 생성
+        User user = User.builder()
+                .email("john@example.com")
+                .username(userName)
+                .refreshToken(null)
+                .role(Role.TECHEER) // Role enum을 사용한다면 적절히 설정
+                .socialType(SocialType.GOOGLE) // SocialType enum을 사용한다면 적절히 설정
+                .build();
+
+        // Resume 객체 생성
+        Resume resume1 = Resume.builder()
+                .id(1L)
+                .name("John's Resume 1")
+                .user(user)
+                .position(Position.BACKEND)
+                .career(5)
+                .resumeTechStacks(new ArrayList<>())
+                .resumeCompanies(new ArrayList<>())
+                .resumePdf(null) // 필요 시 ResumePdf 객체 생성
+                .build();
+
+        Resume resume2 = Resume.builder()
+                .id(2L)
+                .name("John's Resume 2")
+                .user(user)
+                .position(Position.BACKEND)
+                .career(5)
+                .resumeTechStacks(new ArrayList<>())
+                .resumeCompanies(new ArrayList<>())
+                .resumePdf(null) // 필요 시 ResumePdf 객체 생성
+                .build();
+
+        List<Resume> mockedResumes = Arrays.asList(resume1, resume2);
+        when(resumeService.searchResumesByUserName(userName)).thenReturn(mockedResumes);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/resumes/search")
+                        .param("user_name", userName)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.length()").value(2))
+                .andExpect(jsonPath("$.result[0].resumeId").value(1))
+                .andExpect(jsonPath("$.result[0].resumeName").value("John's Resume 1"))
+                .andExpect(jsonPath("$.result[1].resumeId").value(2))
+                .andExpect(jsonPath("$.result[1].resumeName").value("John's Resume 2"));
+
+        verify(resumeService, times(1)).searchResumesByUserName(userName);
+    }
+}

--- a/backend/src/test/java/com/techeer/backend/api/resume/service/ResumeServiceIntegrationTest.java
+++ b/backend/src/test/java/com/techeer/backend/api/resume/service/ResumeServiceIntegrationTest.java
@@ -1,0 +1,99 @@
+package com.techeer.backend.api.resume.service;
+
+import com.techeer.backend.api.resume.domain.Resume;
+import com.techeer.backend.api.resume.repository.ResumeRepository;
+import com.techeer.backend.api.tag.position.Position;
+import com.techeer.backend.api.user.domain.User;
+import com.techeer.backend.api.user.repository.UserRepository;
+import com.techeer.backend.api.user.service.UserService;
+import com.techeer.backend.global.error.exception.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class ResumeServiceIntegrationTest {
+
+    @Autowired
+    private ResumeService resumeService;
+
+    @Autowired
+    private ResumeRepository resumeRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        // 사용자 초기화
+        user = User.builder()
+                .username("john_doe")
+                .build();
+        userRepository.save(user);
+    }
+
+    @Test
+    void getResume_WhenResumeExists_ShouldReturnResume() {
+        // Arrange
+        Resume resume = Resume.builder()
+                .user(user)
+                .name("John's Resume")
+                .career(5)
+                .position(Position.DEVOPS)
+                .build();
+        resumeRepository.save(resume);
+
+        // Act
+        Resume foundResume = resumeService.getResume(resume.getId());
+
+        // Assert
+        assertNotNull(foundResume);
+        assertEquals("John's Resume", foundResume.getName());
+    }
+
+    @Test
+    void getResume_WhenResumeDoesNotExist_ShouldThrowNotFoundException() {
+        // Arrange
+        Long invalidResumeId = 999L;
+
+        // Act & Assert
+        assertThrows(NotFoundException.class, () -> resumeService.getResume(invalidResumeId));
+    }
+
+    @Test
+    void searchResumesByUserName_ShouldReturnResumes() {
+        // Arrange
+        Resume resume1 = Resume.builder()
+                .user(user)
+                .name("John's Resume 1")
+                .career(3)
+                .position(Position.BACKEND)
+                .build();
+
+        Resume resume2 = Resume.builder()
+                .user(user)
+                .name("John's Resume 2")
+                .career(5)
+                .position(Position.BACKEND)
+                .build();
+
+        resumeRepository.save(resume1);
+        resumeRepository.save(resume2);
+
+        // Act
+        var resumes = resumeService.searchResumesByUserName("john_doe");
+
+        // Assert
+        assertEquals(2, resumes.size());
+    }
+}

--- a/backend/src/test/java/com/techeer/backend/api/resume/service/ResumeServiceTest.java
+++ b/backend/src/test/java/com/techeer/backend/api/resume/service/ResumeServiceTest.java
@@ -1,0 +1,121 @@
+// src/test/java/com/techeer/backend/api/resume/service/ResumeServiceTest.java
+
+package com.techeer.backend.api.resume.service;
+
+import com.techeer.backend.api.resume.domain.Resume;
+import com.techeer.backend.api.resume.repository.GetResumeRepository;
+import com.techeer.backend.api.resume.repository.ResumeRepository;
+import com.techeer.backend.global.error.exception.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ResumeServiceTest {
+
+    @InjectMocks
+    private ResumeService resumeService;
+
+    @Mock
+    private ResumeRepository resumeRepository;
+
+    @Mock
+    private GetResumeRepository getResumeRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getResume_WhenResumeExists_ShouldReturnResume() {
+        // Arrange
+        Long resumeId = 1L;
+        Resume resume = mock(Resume.class);
+        when(resume.getId()).thenReturn(resumeId);
+        when(resumeRepository.findById(resumeId)).thenReturn(Optional.of(resume));
+
+        // Act
+        Resume foundResume = resumeService.getResume(resumeId);
+
+        // Assert
+        assertNotNull(foundResume);
+        assertEquals(resumeId, foundResume.getId());
+        verify(resumeRepository, times(1)).findById(resumeId);
+    }
+
+    @Test
+    void getResume_WhenResumeDoesNotExist_ShouldThrowNotFoundException() {
+        // Arrange
+        Long resumeId = 1L;
+        when(resumeRepository.findById(resumeId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(NotFoundException.class, () -> resumeService.getResume(resumeId));
+        verify(resumeRepository, times(1)).findById(resumeId);
+    }
+
+    @Test
+    void searchResumesByUserName_ShouldReturnListOfResumes() {
+        // Arrange
+        String username = "john_doe";
+        Resume resume1 = Resume.builder().build();
+        Resume resume2 = Resume.builder().build();
+        List<Resume> resumes = Arrays.asList(resume1, resume2);
+        when(resumeRepository.findResumesByUsername(username)).thenReturn(resumes);
+
+        // Act
+        List<Resume> result = resumeService.searchResumesByUserName(username);
+
+        // Assert
+        assertEquals(2, result.size());
+        verify(resumeRepository, times(1)).findResumesByUsername(username);
+    }
+
+    @Test
+    void searchResumesByUserName_ShouldReturnListOfResumes1() {
+        // Arrange
+        String userName = "john_doe";
+
+        Resume resume1 = mock(Resume.class);
+        when(resume1.getId()).thenReturn(1L);
+        when(resume1.getName()).thenReturn("John's Resume 1");
+        when(resume1.getUser()).thenReturn(mock(com.techeer.backend.api.user.domain.User.class));
+        when(resume1.getUser().getUsername()).thenReturn(userName);
+        when(resume1.getPosition()).thenReturn(com.techeer.backend.api.tag.position.Position.BACKEND);
+        when(resume1.getCareer()).thenReturn(5);
+        when(resume1.getResumeTechStacks()).thenReturn(Arrays.asList());
+        when(resume1.getResumeCompanies()).thenReturn(Arrays.asList());
+
+        Resume resume2 = mock(Resume.class);
+        when(resume2.getId()).thenReturn(2L);
+        when(resume2.getName()).thenReturn("John's Resume 2");
+        when(resume2.getUser()).thenReturn(mock(com.techeer.backend.api.user.domain.User.class));
+        when(resume2.getUser().getUsername()).thenReturn(userName);
+        when(resume2.getPosition()).thenReturn(com.techeer.backend.api.tag.position.Position.BACKEND);
+        when(resume2.getCareer()).thenReturn(3);
+        when(resume2.getResumeTechStacks()).thenReturn(Arrays.asList());
+        when(resume2.getResumeCompanies()).thenReturn(Arrays.asList());
+
+        List<Resume> mockedResumes = Arrays.asList(resume1, resume2);
+        when(resumeRepository.findResumesByUsername(userName)).thenReturn(mockedResumes);
+
+        // Act
+        List<Resume> result = resumeService.searchResumesByUserName(userName);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(1L, result.get(0).getId());
+        assertEquals("John's Resume 1", result.get(0).getName());
+        assertEquals(2L, result.get(1).getId());
+        assertEquals("John's Resume 2", result.get(1).getName());
+
+        verify(resumeRepository, times(1)).findResumesByUsername(userName);
+    }
+}


### PR DESCRIPTION
## 변경 사항
* ResumeController 테스트 추가
* ResumeService 통합 테스트 추가
* ResumeService 단위 테스트 추가

## 테스트 결과 (테스트를 했으면)
* ResumeControllerTest
  * 이력서 등록 시 201 Created 상태 코드 반환
  * 사용자 이름으로 이력서 검색 시 올바른 이력서 리스트 반환
* ResumeServiceIntegrationTest
  * 존재하는 이력서 조회 시 올바른 이력서 반환
  * 존재하지 않는 이력서 조회 시 NotFoundException 발생
  * 사용자 이름으로 이력서 검색 시 정확한 이력서 리스트 반환
* ResumeServiceTest
  * ResumeRepository와의 상호작용이 정확하게 이루어졌는지 검증
  * 서비스 메서드들이 기대한 대로 동작함을 확인

## +α Checklist
- [ ] 자바 코드 컨벤션을 지키면서 프로그래밍했는가?
- [ ] 한 메서드에 오직 한 단계의 들여쓰기(indent)만 허용했는가?
- [ ] else 예약어를 쓰지 않았는가?
- [ ] 모든 원시값과 문자열을 포장했는가?
- [ ] 콜렉션에 대해 일급 콜렉션을 적용했는가?
- [ ] 3개 이상의 인스턴스 변수를 가진 클래스를 구현하지 않았는가? (가능하면 인스턴스 변수의 수를 줄이기 위해 노력한다.)
- [ ] getter/setter 없이 구현했는가? (단, DTO는 허용한다.)
- [ ] 메소드의 인자 수를 제한했는가? (4개 이상의 인자는 허용하지 않는다. 3개도 가능하면 줄이기 위해 노력해 본다.)
- [ ] 코드 한 줄에 점(.)을 하나만 허용했는가?
- [ ] 메소드가 한가지 일만 담당하도록 구현했는가?
- [ ] 클래스를 작게 유지하기 위해 노력했는가?