### PR TITLE
이력서 버전 관리 추가

### DIFF
--- a/backend/src/main/java/com/techeer/backend/api/resume/converter/ResumeConverter.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/converter/ResumeConverter.java
@@ -44,6 +44,8 @@ public class ResumeConverter {
                         .map(resumeCompany -> resumeCompany.getCompany().getName()).collect(Collectors.toList()))
                 .fileUrl(resume.getResumePdf().getPdf().getPdfUrl())
                 .feedbackResponses(feedbacks.stream().map(FeedbackConverter::toFeedbackResponse).collect(Collectors.toList()))
+                .previousResumeId(resume.getPreviousResumeId() != null ? resume.getPreviousResumeId() : null)
+                .laterResumeId(resume.getLaterResumeId() != null ? resume.getLaterResumeId() : null)
                 .build();
     }
 

--- a/backend/src/main/java/com/techeer/backend/api/resume/converter/ResumeConverter.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/converter/ResumeConverter.java
@@ -7,6 +7,7 @@ import com.techeer.backend.api.resume.dto.response.PageableResumeResponse;
 import com.techeer.backend.api.resume.dto.response.ResumeDetailResponse;
 import com.techeer.backend.api.resume.dto.response.ResumeResponse;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class ResumeConverter {
@@ -44,8 +45,8 @@ public class ResumeConverter {
                         .map(resumeCompany -> resumeCompany.getCompany().getName()).collect(Collectors.toList()))
                 .fileUrl(resume.getResumePdf().getPdf().getPdfUrl())
                 .feedbackResponses(feedbacks.stream().map(FeedbackConverter::toFeedbackResponse).collect(Collectors.toList()))
-                .previousResumeId(resume.getPreviousResumeId() != null ? resume.getPreviousResumeId() : null)
-                .laterResumeId(resume.getLaterResumeId() != null ? resume.getLaterResumeId() : null)
+                .previousResumeId(Optional.ofNullable(resume.getPreviousResumeId()).orElse(null))
+                .laterResumeId(Optional.ofNullable(resume.getLaterResumeId()).orElse(null))
                 .build();
     }
 

--- a/backend/src/main/java/com/techeer/backend/api/resume/domain/Resume.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/domain/Resume.java
@@ -52,6 +52,12 @@ public class Resume extends BaseEntity {
     @Column(name = "position")
     private Position position;
 
+    // 이전 버전(더 오래된 버전)
+    private Long previousResumeId;
+
+    // 이후 버전(더 최신 버전)
+    private Long laterResumeId;
+
     @Builder.Default
     @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL)
     private List<ResumeTechStack> resumeTechStacks = new ArrayList<>();
@@ -83,5 +89,9 @@ public class Resume extends BaseEntity {
 
     public void addResumePdf(ResumePdf resumePdf) {
         this.resumePdf = resumePdf;
+    }
+
+    public void updateLaterResumeId(Long id) {
+        this.laterResumeId = id;
     }
 }

--- a/backend/src/main/java/com/techeer/backend/api/resume/dto/response/ResumeDetailResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/dto/response/ResumeDetailResponse.java
@@ -18,4 +18,7 @@ public class ResumeDetailResponse {
     private List<String> techStackNames;
     private List<String> companyNames;
     private final List<FeedbackResponse> feedbackResponses;
+
+    private final Long previousResumeId;
+    private final Long laterResumeId;
 }

--- a/backend/src/main/java/com/techeer/backend/api/resume/repository/ResumeRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/repository/ResumeRepository.java
@@ -1,6 +1,7 @@
 package com.techeer.backend.api.resume.repository;
 
 import com.techeer.backend.api.resume.domain.Resume;
+import com.techeer.backend.api.user.domain.User;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +17,6 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
     List<Resume> findResumesByUsername(@Param("username") String username);
 
     Optional<Resume> findByIdAndDeletedAtIsNull(Long resumeId);
+
+    Resume findFirstByUserOrderByCreatedAtDesc(User user);
 }

--- a/backend/src/main/java/com/techeer/backend/api/resume/service/ResumeService.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/service/ResumeService.java
@@ -4,6 +4,7 @@ import com.techeer.backend.api.resume.domain.Resume;
 import com.techeer.backend.api.resume.dto.request.ResumeSearchRequest;
 import com.techeer.backend.api.resume.repository.GetResumeRepository;
 import com.techeer.backend.api.resume.repository.ResumeRepository;
+import com.techeer.backend.api.user.domain.User;
 import com.techeer.backend.global.error.ErrorStatus;
 import com.techeer.backend.global.error.exception.GeneralException;
 import com.techeer.backend.global.error.exception.NotFoundException;
@@ -78,5 +79,9 @@ public class ResumeService {
         }
 
         return resumes;
+    }
+
+    public Resume findLaterByUser(User user) {
+        return resumeRepository.findFirstByUserOrderByCreatedAtDesc(user);
     }
 }

--- a/backend/src/main/java/com/techeer/backend/api/resume/service/facade/ResumeCreateFacade.java
+++ b/backend/src/main/java/com/techeer/backend/api/resume/service/facade/ResumeCreateFacade.java
@@ -20,7 +20,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.servlet.mvc.HttpRequestHandlerAdapter;
 
 @Service
 @RequiredArgsConstructor
@@ -32,7 +31,6 @@ public class ResumeCreateFacade {
     private final TechStackService techStackService;
     private final ResumePdfService resumePdfService;
     private final UserService userService;
-    private final HttpRequestHandlerAdapter httpRequestHandlerAdapter;
 
     // 이력서 생성
     @Transactional


### PR DESCRIPTION
## 변경 사항

- 이력서에 이전 이력서 Id, 이후 이력서 Id 컬럼을 추가하여 생성 시 사용자의 이전 이력서 Id를 해당 이력서의 필드값으로 추가
- 이력서 개별 조회 시 id 값을 줌으로써 이력서 버전 이동을 할 수 있게 함
- 이에 따라 Docker 빌드를 다시 해야 함

## 추가 고려 사항

- 이후에 SI, Service, Startup 등 회사 종류에 따라 이력서 버전을 따로 관리하고 싶은 경우 수정 사항이 필요


## 테스트 결과 (테스트를 했으면)

#### database
![image](https://github.com/user-attachments/assets/5c4e0052-5168-4864-8dbe-be3030f39326)

#### 이력서 생성
![image](https://github.com/user-attachments/assets/8cfa9c49-5556-436b-bc2e-434c42eb852e)

#### 이력서 개별 조회
![image](https://github.com/user-attachments/assets/4d8cdc17-f4fa-435a-a281-ca8536087a08)

