### PR TITLE
[fix] 이력서 비로그인 회원 조회 가능

### DIFF
--- a/backend/src/main/java/com/techeer/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/techeer/backend/global/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -64,6 +65,10 @@ public class SecurityConfig {
 //                        .anyRequest().permitAll()
 //                )
                 .authorizeHttpRequests(authorize -> authorize
+
+                        // 특정 엔드포인트에서 GET 요청만 허용
+                        .requestMatchers(HttpMethod.GET, "/api/v1/resumes").permitAll()
+
                         .requestMatchers(
                                 "/v3/api-docs/**",
                                 "/oauth2/**",

--- a/backend/src/main/java/com/techeer/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/techeer/backend/global/config/SecurityConfig.java
@@ -67,7 +67,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
 
                         // 특정 엔드포인트에서 GET 요청만 허용
-                        .requestMatchers(HttpMethod.GET, "/api/v1/resumes").permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/resumes",
+                                "/api/v1/resumes/view"
+                        ).permitAll()
 
                         .requestMatchers(
                                 "/v3/api-docs/**",
@@ -80,7 +83,8 @@ public class SecurityConfig {
                                 "/api-docs/**",
                                 "/signup.html",
                                 "/login",
-                                "/api/v1/mock/signup"
+                                "/api/v1/mock/signup",
+                                "/api/v1/resumes/search"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 변경 사항

Spring Security에서 permitall url endpoint에 이력서 개별 조회 or 유저 조회를 제외한 나머지 조회 url 추가
해당 api 호출 시 인증 인가 로직이 발생하지 않아 api 사용 가능


## 테스트 결과 (테스트를 했으면)
확인은 다 했는데, 테스트 이미지는 첨부하지 않겠습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Made resume viewing endpoints publicly accessible.
	- Updated the resume search endpoint to allow easier GET access without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->