### PR TITLE
코드 포매팅, 대량 Mock Data 생성 기능 추가

### DIFF
--- a/backend/.cursor/rules/dto-formatting-conventions.mdc
+++ b/backend/.cursor/rules/dto-formatting-conventions.mdc
@@ -1,0 +1,122 @@
+# DTO (Record) 포맷팅 규칙
+
+## Request/Response DTO 포맷팅 스타일
+
+모든 `record` 타입의 DTO는 다음 포맷팅 규칙을 따라야 합니다.
+
+### 기본 구조
+
+```java
+public record ExampleRequest(
+
+    @Annotation1
+    @Annotation2
+    Type field1,
+
+    @Annotation3
+    Type field2
+
+) {
+
+}
+```
+
+### 상세 규칙
+
+1. **record 선언 후**: 빈 줄 **1개**
+2. **어노테이션**: 같은 필드의 어노테이션은 연속으로 작성 (빈 줄 없음)
+3. **어노테이션과 필드 사이**: 빈 줄 **없음** (붙여서 작성)
+4. **필드명 후**: `,` 다음 빈 줄 **1개**
+5. **마지막 필드 후**: 빈 줄 **1개**
+6. **닫는 괄호 `)`**: 별도 줄
+7. **중괄호 `{` 전**: 빈 줄 **1개**
+8. **중괄호 `}` 내부**: 빈 줄 **1개**
+
+### 예시 1: 단순 DTO
+
+```java
+public record LoginRequest(
+
+    @NotBlank(message = "이메일을 입력하세요")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    String email,
+
+    @NotBlank(message = "비밀번호를 입력하세요")
+    String password
+
+) {
+
+}
+```
+
+### 예시 2: 복잡한 DTO
+
+```java
+public record RegisterRequest(
+
+    @NotBlank(message = "이메일을 입력하세요")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    String email,
+
+    @NotBlank(message = "이름을 입력하세요")
+    String username,
+
+    @NotBlank(message = "비밀번호를 입력하세요")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다")
+    @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*#?&]{8,}$",
+        message = "비밀번호는 영문자와 숫자를 포함해야 합니다"
+    )
+    String password
+
+) {
+
+}
+```
+
+### 예시 3: 어노테이션 없는 필드
+
+```java
+public record JobPostingCreateRequest(
+
+    @NotNull(message = "회사 ID는 필수입니다")
+    Long companyId,
+
+    @NotNull(message = "제목은 필수입니다")
+    @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다")
+    String title,
+
+    String contents,
+
+    Integer expYears
+
+) {
+
+}
+```
+
+### 예시 4: Response DTO (Builder 포함)
+
+```java
+@Builder
+public record ResumeInfoResponse(
+
+    Long id,
+
+    String title,
+
+    String fileUrl,
+
+    Boolean isDefault
+
+) {
+
+}
+```
+
+## 주의사항
+
+- ❌ IntelliJ 자동 포맷팅(`Cmd+Option+L` / `Ctrl+Alt+L`) 사용 시 이 규칙이 무시됨
+- ✅ 새로운 DTO 작성 시 기존 DTO를 복사하여 스타일 유지
+- ✅ PR 시 DTO 포맷 체크 필수
+- ✅ 들여쓰기는 스페이스 4칸 사용

--- a/backend/docs/API_FEATURES.md
+++ b/backend/docs/API_FEATURES.md
@@ -24,18 +24,49 @@
 <summary><b>회원가입 (자체 로그인)</b></summary>
 
 - **Endpoint**: `POST /api/v1/auth/register`
-- **Request**: `RegisterRequest` (email, password, name, role)
+- **Request**: `RegisterRequest` (email, password, username)
 - **Response**: `ApiResponse<Void>`
 - **권한**: 인증 불필요
+
+**curl 명령어:**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "testuser@example.com",
+    "username": "테스트유저",
+    "password": "Test1234!"
+  }'
+```
+
 </details>
 
 <details>
 <summary><b>로그인 (자체 로그인)</b></summary>
 
 - **Endpoint**: `POST /api/v1/auth/login`
-- **Request**: `LoginRequest` (email, password, socialType)
+- **Request**: `LoginRequest` (email, password)
 - **Response**: `ApiResponse<Void>` + JWT 쿠키 설정
 - **권한**: 인증 불필요
+
+**curl 명령어:**
+
+```bash
+# 로그인 (쿠키에 토큰 저장)
+curl -X POST http://localhost:8080/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "testuser@example.com",
+    "password": "Test1234!"
+  }' \
+  -c cookies.txt
+
+# 이후 요청에서 쿠키 사용
+curl -X GET http://localhost:8080/api/v1/user \
+  -b cookies.txt
+```
+
 </details>
 
 <details>
@@ -50,9 +81,21 @@
 <summary><b>추가 정보 입력</b></summary>
 
 - **Endpoint**: `POST /api/v1/user`
-- **Request**: `SignUpRequest` (name, role)
+- **Request**: `SignUpRequest` (name)
 - **Response**: `ApiResponse<Void>`
 - **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/user \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -d '{
+    "name": "홍길동"
+  }'
+```
+
 </details>
 
 <details>
@@ -61,6 +104,19 @@
 - **Endpoint**: `GET /api/v1/user`
 - **Response**: `ApiResponse<UserInfoResponse>`
 - **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+# 쿠키 사용
+curl -X GET http://localhost:8080/api/v1/user \
+  -b cookies.txt
+
+# 또는 Authorization 헤더 사용
+curl -X GET http://localhost:8080/api/v1/user \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 <details>
@@ -70,6 +126,15 @@
 - **Request**: `MultipartFile` (file)
 - **Response**: `ApiResponse<String>` (이미지 URL)
 - **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X PATCH http://localhost:8080/api/v1/user/profile-image \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -F "file=@/path/to/image.jpg"
+```
+
 </details>
 
 <details>
@@ -98,10 +163,34 @@
 
 - **UseCase**: `RegisterCompanyUseCase`
 - **Endpoint**: `POST /api/v1/companies`
-- **Request**: `CompanyRegisterRequest` (name, industryDomain, websiteUrl, location)
+- **Request**: `CompanyRegisterRequest` (name, companyEmail, industryDomain, websiteUrl, location)
 - **Response**: `ApiResponse<Long>` (companyId)
 - **권한**: 인증 필요
 - **비즈니스 로직**: 등록한 사용자는 자동으로 ADMIN 권한 부여
+
+**curl 명령어 (snake_case 필수, 모든 필드 포함):**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/companies \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{
+    "name": "네이버",
+    "company_email": "recruit@naver.com",
+    "industry_domain": "IT/인터넷",
+    "website_url": "https://www.naver.com",
+    "location": "경기도 성남시 분당구"
+  }'
+```
+
+**필드 설명:**
+
+- `name` (필수): 기업명
+- `company_email` (선택): 기업 이메일
+- `industry_domain` (선택): 산업 분야
+- `website_url` (선택): 웹사이트 URL
+- `location` (선택): 위치
+
 </details>
 
 <details>
@@ -111,6 +200,14 @@
 - **Endpoint**: `GET /api/v1/companies/{companyId}`
 - **Response**: `ApiResponse<CompanyInfoResponse>`
 - **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET http://localhost:8080/api/v1/companies/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 <details>
@@ -118,9 +215,25 @@
 
 - **UseCase**: `UpdateCompanyUseCase`
 - **Endpoint**: `PUT /api/v1/companies/{companyId}`
-- **Request**: `CompanyUpdateRequest` (name, industryDomain, websiteUrl, location)
+- **Request**: `CompanyUpdateRequest` (name, companyEmail, industryDomain, websiteUrl, location)
 - **Response**: `ApiResponse<Void>`
 - **권한**: 기업 ADMIN만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X PUT http://localhost:8080/api/v1/companies/1 \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -d '{
+    "name": "테크컴퍼니 (수정)",
+    "companyEmail": "newcontact@techcompany.com",
+    "industryDomain": "IT/소프트웨어",
+    "websiteUrl": "https://techcompany.com",
+    "location": "서울시 강남구"
+  }'
+```
+
 </details>
 
 <details>
@@ -130,6 +243,14 @@
 - **Endpoint**: `DELETE /api/v1/companies/{companyId}`
 - **Response**: `ApiResponse<Void>`
 - **권한**: 기업 ADMIN만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/companies/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 ---
@@ -145,6 +266,19 @@
 - **Response**: `ApiResponse<Long>` (likeId)
 - **권한**: 인증 필요
 - **비즈니스 로직**: 중복 좋아요 불가
+
+**curl 명령어 (snake_case 필수, user_id 필수):**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/company-likes \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{
+    "company_id": 1,
+    "user_id": 1
+  }'
+```
+
 </details>
 
 <details>
@@ -154,6 +288,14 @@
 - **Endpoint**: `GET /api/v1/company-likes/{companyLikeId}`
 - **Response**: `ApiResponse<CompanyLikeInfoResponse>`
 - **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET http://localhost:8080/api/v1/company-likes/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 <details>
@@ -163,6 +305,14 @@
 - **Endpoint**: `DELETE /api/v1/company-likes/{companyLikeId}`
 - **Response**: `ApiResponse<Void>`
 - **권한**: 본인만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/company-likes/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 ---
@@ -177,6 +327,28 @@
 - **Request**: `JobPostingCreateRequest` (companyId, title, contents, expYears)
 - **Response**: `ApiResponse<Long>` (jobPostingId)
 - **권한**: 해당 기업의 ADMIN만 가능
+
+**curl 명령어 (snake_case 필수, 모든 필드 포함):**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/job-postings \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{
+    "company_id": 3,
+    "title": "프론트엔드 개발자 채용",
+    "contents": "React, TypeScript 경험자 우대\n- 2년 이상 경력\n- 컴포넌트 설계 경험\n- 상태 관리 라이브러리 사용 가능자\n- 협업 능력 우대",
+    "exp_years": 2
+  }'
+```
+
+**필드 설명:**
+
+- `company_id` (필수): 기업 ID
+- `title` (필수): 채용공고 제목
+- `contents` (선택): 채용공고 내용
+- `exp_years` (선택): 요구 경력 연수
+
 </details>
 
 <details>
@@ -186,6 +358,14 @@
 - **Endpoint**: `GET /api/v1/job-postings/{jobPostingId}`
 - **Response**: `ApiResponse<JobPostingInfoResponse>`
 - **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET http://localhost:8080/api/v1/job-postings/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 <details>
@@ -196,6 +376,20 @@
 - **Request**: `JobPostingUpdateRequest` (title, contents, expYears)
 - **Response**: `ApiResponse<Void>`
 - **권한**: 해당 기업의 ADMIN만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X PUT http://localhost:8080/api/v1/job-postings/1 \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -d '{
+    "title": "백엔드 개발자 채용 (수정)",
+    "contents": "Spring Boot 경험자 필수",
+    "expYears": 5
+  }'
+```
+
 </details>
 
 <details>
@@ -205,6 +399,14 @@
 - **Endpoint**: `DELETE /api/v1/job-postings/{jobPostingId}`
 - **Response**: `ApiResponse<Void>`
 - **권한**: 해당 기업의 ADMIN만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/job-postings/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 ---
@@ -220,6 +422,18 @@
 - **Response**: `ApiResponse<Long>` (applicationId)
 - **권한**: 인증 필요
 - **비즈니스 로직**: 중복 지원 불가
+
+**curl 명령어 (snake_case 필수):**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/applications \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{
+    "job_posting_id": 1
+  }'
+```
+
 </details>
 
 <details>
@@ -229,6 +443,14 @@
 - **Endpoint**: `GET /api/v1/applications/{applicationId}`
 - **Response**: `ApiResponse<ApplicationInfoResponse>`
 - **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET http://localhost:8080/api/v1/applications/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 <details>
@@ -238,6 +460,14 @@
 - **Endpoint**: `DELETE /api/v1/applications/{applicationId}`
 - **Response**: `ApiResponse<Void>`
 - **권한**: 본인만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/applications/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 ---
@@ -253,6 +483,18 @@
 - **Response**: `ApiResponse<Long>` (bookmarkId)
 - **권한**: 인증 필요
 - **비즈니스 로직**: 중복 북마크 불가
+
+**curl 명령어 (snake_case 필수):**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/bookmarks \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{
+    "job_posting_id": 1
+  }'
+```
+
 </details>
 
 <details>
@@ -262,6 +504,31 @@
 - **Endpoint**: `GET /api/v1/bookmarks/{bookmarkId}`
 - **Response**: `ApiResponse<BookmarkInfoResponse>`
 - **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET http://localhost:8080/api/v1/bookmarks/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+</details>
+
+<details>
+<summary><b>북마크 전체 조회</b></summary>
+
+- **UseCase**: `GetAllBookmarksUseCase`
+- **Endpoint**: `GET /api/v1/bookmarks?page=0&size=10`
+- **Response**: `ApiResponse<Slice<BookmarkInfoResponse>>`
+- **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET "http://localhost:8080/api/v1/bookmarks?page=0&size=10" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 <details>
@@ -271,6 +538,14 @@
 - **Endpoint**: `DELETE /api/v1/bookmarks/{bookmarkId}`
 - **Response**: `ApiResponse<Void>`
 - **권한**: 본인만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/bookmarks/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 ---
@@ -288,6 +563,16 @@
 - **Response**: `ApiResponse<Long>` (resumeId)
 - **권한**: 인증 필요
 - **파일 업로드**: GCS에 저장 후 UserFile 엔티티 생성
+
+**curl 명령어:**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/resumes \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -F 'request={"title":"내 이력서","isDefault":true};type=application/json' \
+  -F 'file=@/path/to/resume.pdf'
+```
+
 </details>
 
 <details>
@@ -297,6 +582,31 @@
 - **Endpoint**: `GET /api/v1/resumes/{resumeId}`
 - **Response**: `ApiResponse<ResumeInfoResponse>`
 - **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET http://localhost:8080/api/v1/resumes/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+</details>
+
+<details>
+<summary><b>이력서 전체 조회</b></summary>
+
+- **UseCase**: `GetAllResumesUseCase`
+- **Endpoint**: `GET /api/v1/resumes?page=0&size=10`
+- **Response**: `ApiResponse<Slice<ResumeInfoResponse>>`
+- **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET "http://localhost:8080/api/v1/resumes?page=0&size=10" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 <details>
@@ -307,6 +617,19 @@
 - **Request**: `ResumeUpdateRequest` (title, isDefault)
 - **Response**: `ApiResponse<Void>`
 - **권한**: 본인만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X PUT http://localhost:8080/api/v1/resumes/1 \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -d '{
+    "title": "내 이력서 (수정)",
+    "isDefault": false
+  }'
+```
+
 </details>
 
 <details>
@@ -316,6 +639,14 @@
 - **Endpoint**: `DELETE /api/v1/resumes/{resumeId}`
 - **Response**: `ApiResponse<Void>`
 - **권한**: 본인만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/resumes/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 ---
@@ -333,6 +664,90 @@
 - **Response**: `ApiResponse<Long>` (portfolioId)
 - **권한**: 인증 필요
 - **파일 업로드**: GCS에 저장 후 UserFile 엔티티 생성
+
+**curl 명령어:**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/portfolios \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -F 'request={"title":"내 포트폴리오","isDefault":true};type=application/json' \
+  -F 'file=@/path/to/portfolio.pdf'
+```
+
+</details>
+
+<details>
+<summary><b>포트폴리오 단건 조회</b></summary>
+
+- **UseCase**: `GetPortfolioUseCase`
+- **Endpoint**: `GET /api/v1/portfolios/{portfolioId}`
+- **Response**: `ApiResponse<PortfolioInfoResponse>`
+- **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET http://localhost:8080/api/v1/portfolios/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+</details>
+
+<details>
+<summary><b>포트폴리오 전체 조회</b></summary>
+
+- **UseCase**: `GetAllPortfoliosUseCase`
+- **Endpoint**: `GET /api/v1/portfolios?page=0&size=10`
+- **Response**: `ApiResponse<Slice<PortfolioInfoResponse>>`
+- **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET "http://localhost:8080/api/v1/portfolios?page=0&size=10" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+</details>
+
+<details>
+<summary><b>포트폴리오 수정</b></summary>
+
+- **UseCase**: `UpdatePortfolioUseCase`
+- **Endpoint**: `PUT /api/v1/portfolios/{portfolioId}`
+- **Request**: `PortfolioUpdateRequest` (title, isDefault)
+- **Response**: `ApiResponse<Void>`
+- **권한**: 본인만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X PUT http://localhost:8080/api/v1/portfolios/1 \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -d '{
+    "title": "내 포트폴리오 (수정)",
+    "isDefault": false
+  }'
+```
+
+</details>
+
+<details>
+<summary><b>포트폴리오 삭제 (Soft Delete)</b></summary>
+
+- **UseCase**: `DeletePortfolioUseCase`
+- **Endpoint**: `DELETE /api/v1/portfolios/{portfolioId}`
+- **Response**: `ApiResponse<Void>`
+- **권한**: 본인만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/portfolios/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 ---
@@ -350,6 +765,90 @@
 - **Response**: `ApiResponse<Long>` (educationId)
 - **권한**: 인증 필요
 - **파일 업로드**: GCS verification 폴더에 저장
+
+**curl 명령어:**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/educations \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -F 'request={"title":"학사 학위","isDefault":true};type=application/json' \
+  -F 'file=@/path/to/degree.pdf'
+```
+
+</details>
+
+<details>
+<summary><b>학력 단건 조회</b></summary>
+
+- **UseCase**: `GetEducationUseCase`
+- **Endpoint**: `GET /api/v1/educations/{educationId}`
+- **Response**: `ApiResponse<EducationInfoResponse>`
+- **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET http://localhost:8080/api/v1/educations/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+</details>
+
+<details>
+<summary><b>학력 전체 조회</b></summary>
+
+- **UseCase**: `GetAllEducationsUseCase`
+- **Endpoint**: `GET /api/v1/educations?page=0&size=10`
+- **Response**: `ApiResponse<Slice<EducationInfoResponse>>`
+- **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET "http://localhost:8080/api/v1/educations?page=0&size=10" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+</details>
+
+<details>
+<summary><b>학력 수정</b></summary>
+
+- **UseCase**: `UpdateEducationUseCase`
+- **Endpoint**: `PUT /api/v1/educations/{educationId}`
+- **Request**: `EducationUpdateRequest` (title, isDefault)
+- **Response**: `ApiResponse<Void>`
+- **권한**: 본인만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X PUT http://localhost:8080/api/v1/educations/1 \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -d '{
+    "title": "학사 학위 (수정)",
+    "isDefault": false
+  }'
+```
+
+</details>
+
+<details>
+<summary><b>학력 삭제 (Soft Delete)</b></summary>
+
+- **UseCase**: `DeleteEducationUseCase`
+- **Endpoint**: `DELETE /api/v1/educations/{educationId}`
+- **Response**: `ApiResponse<Void>`
+- **권한**: 본인만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/educations/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 ---
@@ -364,6 +863,43 @@
 - **Request**: `UserCareerCreateRequest` (companyName, jobTitle, isCurrent, startDate, endDate)
 - **Response**: `ApiResponse<Long>` (careerId)
 - **권한**: 인증 필요
+
+**curl 명령어 (snake_case 필수, 모든 필드 포함):**
+
+```bash
+# 현재 재직 중인 경우
+curl -X POST http://localhost:8080/api/v1/user-careers \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{
+    "company_name": "테크컴퍼니",
+    "job_title": "백엔드 개발자",
+    "is_current": true,
+    "start_date": "2023-01-01",
+    "end_date": null
+  }'
+
+# 과거 경력인 경우
+curl -X POST http://localhost:8080/api/v1/user-careers \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{
+    "company_name": "카카오",
+    "job_title": "시니어 백엔드 개발자",
+    "is_current": false,
+    "start_date": "2020-01-01",
+    "end_date": "2022-12-31"
+  }'
+```
+
+**필드 설명:**
+
+- `company_name` (필수): 회사명
+- `job_title` (선택): 직책
+- `is_current` (선택): 현재 재직 여부
+- `start_date` (선택): 시작일 (YYYY-MM-DD)
+- `end_date` (선택): 종료일 (YYYY-MM-DD), 현재 재직 중이면 null
+
 </details>
 
 <details>
@@ -373,6 +909,14 @@
 - **Endpoint**: `GET /api/v1/user-careers/{careerId}`
 - **Response**: `ApiResponse<UserCareerInfoResponse>`
 - **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET http://localhost:8080/api/v1/user-careers/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 <details>
@@ -383,6 +927,22 @@
 - **Request**: `UserCareerUpdateRequest` (companyName, jobTitle, isCurrent, startDate, endDate)
 - **Response**: `ApiResponse<Void>`
 - **권한**: 본인만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X PUT http://localhost:8080/api/v1/user-careers/1 \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -d '{
+    "companyName": "테크컴퍼니 (수정)",
+    "jobTitle": "시니어 백엔드 개발자",
+    "isCurrent": true,
+    "startDate": "2023-01-01",
+    "endDate": null
+  }'
+```
+
 </details>
 
 <details>
@@ -392,11 +952,255 @@
 - **Endpoint**: `DELETE /api/v1/user-careers/{careerId}`
 - **Response**: `ApiResponse<Void>`
 - **권한**: 본인만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/user-careers/1 \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 </details>
 
 ---
 
-## UserSkill (스킬)
+## Skill (기술 스택)
+
+<details>
+<summary><b>기술 스택 등록</b></summary>
+
+- **UseCase**: `CreateSkillUseCase`
+- **Endpoint**: `POST /api/v1/skills`
+- **Request**: `SkillCreateRequest` (name)
+- **Response**: `ApiResponse<Long>` (skillId)
+- **권한**: 인증 필요 (모든 사용자 가능)
+- **비즈니스 로직**:
+  - 스킬명 중복 체크 (대소문자 구분 없이)
+  - "Java" 등록 후 "java" 또는 "JAVA" 등록 시도 시 `SKILL_409` 에러 발생
+
+**curl 명령어:**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/skills \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{
+    "name": "Java"
+  }'
+```
+
+**필드 설명:**
+
+- `name` (필수): 기술 스택명 (최대 100자)
+
+**테스트 결과:**
+
+```bash
+# 성공 예시
+curl -X POST http://localhost:8080/api/v1/skills \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{"name": "Java"}'
+# 응답: {"success":true,"message":"기술 스택이 등록되었습니다.","data":1}
+
+# 중복 등록 시도 (대소문자 구분 없이)
+curl -X POST http://localhost:8080/api/v1/skills \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{"name": "java"}'
+# 응답: {"http_status":"CONFLICT","code":"SKILL_409","error_message":"이미 존재하는 스킬입니다."}
+```
+
+</details>
+
+<details>
+<summary><b>기술 스택 단건 조회</b></summary>
+
+- **UseCase**: `GetSkillUseCase`
+- **Endpoint**: `GET /api/v1/skills/{skillId}`
+- **Response**: `ApiResponse<SkillInfoResponse>` (id, name)
+- **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET http://localhost:8080/api/v1/skills/1 \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN"
+```
+
+**응답 예시:**
+
+```json
+{
+  "success": true,
+  "message": "기술 스택 조회에 성공했습니다.",
+  "data": {
+    "id": 1,
+    "name": "Java"
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>기술 스택 수정</b></summary>
+
+- **UseCase**: `UpdateSkillUseCase`
+- **Endpoint**: `PUT /api/v1/skills/{skillId}`
+- **Request**: `SkillUpdateRequest` (name)
+- **Response**: `ApiResponse<Void>`
+- **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X PUT http://localhost:8080/api/v1/skills/1 \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{
+    "name": "Java 17"
+  }'
+```
+
+**필드 설명:**
+
+- `name` (선택): 기술 스택명 (최대 100자)
+
+**테스트 결과:**
+
+```bash
+# 수정 성공
+curl -X PUT http://localhost:8080/api/v1/skills/1 \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{"name": "Java 17"}'
+# 응답: {"success":true,"message":"기술 스택이 수정되었습니다."}
+
+# 수정 시 중복 체크
+curl -X PUT http://localhost:8080/api/v1/skills/1 \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{"name": "Spring Boot"}'
+# 응답: {"http_status":"CONFLICT","code":"SKILL_409","error_message":"이미 존재하는 스킬입니다."}
+```
+
+</details>
+
+<details>
+<summary><b>기술 스택 삭제 (Soft Delete)</b></summary>
+
+- **UseCase**: `DeleteSkillUseCase`
+- **Endpoint**: `DELETE /api/v1/skills/{skillId}`
+- **Response**: `ApiResponse<Void>`
+- **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/skills/1 \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN"
+```
+
+**테스트 결과:**
+
+```bash
+# 삭제 성공
+curl -X DELETE http://localhost:8080/api/v1/skills/2 \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN"
+# 응답: {"success":true,"message":"기술 스택이 삭제되었습니다."}
+
+# 삭제 후 조회 시도
+curl -X GET http://localhost:8080/api/v1/skills/2 \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN"
+# 응답: {"http_status":"NOT_FOUND","code":"SKILL_404","error_message":"스킬을 찾을 수 없습니다."}
+```
+
+**참고:**
+
+- Soft Delete로 삭제되므로 `deletedAt`이 설정됩니다. 삭제된 스킬은 조회되지 않습니다.
+- 삭제 후 다시 등록 가능 (Soft Delete된 스킬은 중복 체크에서 제외)
+
+**테스트 결과:**
+
+```bash
+# 삭제 성공
+curl -X DELETE http://localhost:8080/api/v1/skills/6 \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN"
+# 응답: {"success":true,"message":"기술 스택이 삭제되었습니다."}
+
+# 삭제 후 조회 시도
+curl -X GET http://localhost:8080/api/v1/skills/6 \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN"
+# 응답: {"http_status":"NOT_FOUND","code":"SKILL_404","error_message":"스킬을 찾을 수 없습니다."}
+
+# 삭제 후 다시 등록 가능
+curl -X POST http://localhost:8080/api/v1/skills \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{"name": "React"}'
+# 응답: {"success":true,"message":"기술 스택이 등록되었습니다.","data":9}
+```
+
+</details>
+
+---
+
+## UserSkill (사용자 스킬)
+
+### ⚠️ 사전 준비: Skill 데이터 생성
+
+UserSkill API를 테스트하기 전에 **Skill 데이터를 먼저 생성**해야 합니다. Skill API를 사용하여 기술 스택을 등록하거나, 아래 SQL을 사용하여 직접 생성할 수 있습니다.
+
+**Skill 데이터 생성 SQL:**
+
+```sql
+-- 기술 스택 데이터 생성
+INSERT INTO skills (name, created_at, updated_at) VALUES
+('Java', NOW(), NOW()),
+('Spring Boot', NOW(), NOW()),
+('Python', NOW(), NOW()),
+('JavaScript', NOW(), NOW()),
+('TypeScript', NOW(), NOW()),
+('React', NOW(), NOW()),
+('Node.js', NOW(), NOW()),
+('MySQL', NOW(), NOW()),
+('PostgreSQL', NOW(), NOW()),
+('Redis', NOW(), NOW()),
+('Docker', NOW(), NOW()),
+('Kubernetes', NOW(), NOW()),
+('AWS', NOW(), NOW()),
+('Git', NOW(), NOW()),
+('JPA', NOW(), NOW()),
+('QueryDSL', NOW(), NOW())
+ON DUPLICATE KEY UPDATE updated_at = NOW();
+```
+
+**SQL 실행 방법 (선택사항):**
+
+```bash
+# Docker Compose 사용 시
+docker compose -f docker-compose.dev.yml exec mysql mysql -uroot -p[비밀번호] techeer < create_skills.sql
+
+# 또는 MySQL 클라이언트로 직접 접속
+mysql -h localhost -u root -p techeer < create_skills.sql
+```
+
+**또는 Skill API를 사용하여 직접 등록:**
+
+```bash
+# Java 등록
+curl -X POST http://localhost:8080/api/v1/skills \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{"name": "Java"}'
+
+# Spring Boot 등록
+curl -X POST http://localhost:8080/api/v1/skills \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{"name": "Spring Boot"}'
+```
 
 <details>
 <summary><b>스킬 등록</b></summary>
@@ -407,6 +1211,29 @@
 - **Response**: `ApiResponse<Long>` (userSkillId)
 - **권한**: 인증 필요
 - **비즈니스 로직**: 중복 스킬 등록 불가
+
+**curl 명령어 (snake_case 필수):**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/user-skills \
+  -H "Content-Type: application/json" \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
+  -d '{
+    "skill_id": 1
+  }'
+```
+
+**필드 설명:**
+
+- `skill_id` (필수): Skill ID (DB에 존재하는 skill_id여야 함)
+
+**예시:**
+
+- `skill_id: 1` → Java
+- `skill_id: 2` → Spring Boot
+- `skill_id: 3` → Python
+</details>
+
 </details>
 
 <details>
@@ -414,8 +1241,31 @@
 
 - **UseCase**: `GetUserSkillUseCase`
 - **Endpoint**: `GET /api/v1/user-skills/{userSkillId}`
-- **Response**: `ApiResponse<UserSkillInfoResponse>`
+- **Response**: `ApiResponse<UserSkillInfoResponse>` (id, userId, skillId, skillName)
 - **권한**: 인증 필요
+
+**curl 명령어:**
+
+```bash
+curl -X GET http://localhost:8080/api/v1/user-skills/1 \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN"
+```
+
+**응답 예시:**
+
+```json
+{
+  "success": true,
+  "message": "성공적으로 처리되었습니다.",
+  "data": {
+    "id": 1,
+    "user_id": 1,
+    "skill_id": 1,
+    "skill_name": "Java"
+  }
+}
+```
+
 </details>
 
 <details>
@@ -425,6 +1275,22 @@
 - **Endpoint**: `DELETE /api/v1/user-skills/{userSkillId}`
 - **Response**: `ApiResponse<Void>`
 - **권한**: 본인만 가능
+
+**curl 명령어:**
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/user-skills/1 \
+  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN"
+```
+
+**테스트 시나리오:**
+
+1. 스킬 등록 (skill_id: 1)
+2. 스킬 조회 (userSkillId: 1)
+3. 중복 스킬 등록 시도 → 에러 발생 (USER_SKILL_ALREADY_EXISTS)
+4. 스킬 삭제 (userSkillId: 1)
+5. 삭제 후 다시 등록 가능
+
 </details>
 
 ---
@@ -442,6 +1308,76 @@
 2. 응답에서 받은 `accessToken` 복사
 3. Swagger UI 우측 상단 "Authorize" 버튼 클릭
 4. 토큰 입력 (Bearer 접두사는 자동 추가)
+
+### API 테스트 방법
+
+#### ⚠️ 중요: Request Body는 Snake Case로 전송해야 합니다
+
+서버는 **snake_case**를 자동으로 **camelCase**로 변환합니다. 모든 Request Body는 **snake_case** 형식으로 보내야 합니다.
+
+**예시:**
+
+- ❌ `{"companyId": 1}` → 파싱 실패
+- ✅ `{"company_id": 1}` → 성공
+
+#### curl 테스트 방법
+
+**1. Mock 유저 생성 및 토큰 발급:**
+
+```bash
+curl -X POST "http://localhost:8080/api/v1/mock/signup?id=testuser"
+# 응답에서 accessToken 추출
+```
+
+**2. 쿠키 파일 사용 (로그인 후):**
+
+```bash
+# 로그인하여 쿠키 저장
+curl -X POST http://localhost:8080/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@example.com","password":"Test1234!"}' \
+  -c cookies.txt
+
+# 이후 요청에서 쿠키 사용
+curl -X GET http://localhost:8080/api/v1/user -b cookies.txt
+```
+
+**3. Authorization 헤더 사용:**
+
+```bash
+curl -X GET http://localhost:8080/api/v1/user \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+#### 테스트 결과 요약
+
+**✅ 성공한 API (테스트 완료):**
+
+- 회원가입, 로그인, 유저 정보 조회
+- 기업 등록, 조회
+- 채용공고 등록, 조회 (snake_case 사용)
+- 채용공고 지원 (snake_case 사용)
+- 북마크 등록, 조회 (snake_case 사용)
+- 기업 좋아요 (snake_case 사용, user_id 필수)
+- 경력 등록, 조회 (snake_case 사용)
+- 이력서/포트폴리오/학력 전체 조회
+- **기술 스택 등록, 조회, 수정, 삭제 (신규 추가)**
+  - 대소문자 구분 없이 중복 체크 작동 확인
+  - 모든 사용자가 등록/수정/삭제 가능
+  - Soft Delete로 삭제 후 조회 불가
+
+**📝 Snake Case 필드명 매핑:**
+
+- `companyId` → `company_id`
+- `jobPostingId` → `job_posting_id`
+- `companyName` → `company_name`
+- `jobTitle` → `job_title`
+- `isCurrent` → `is_current`
+- `startDate` → `start_date`
+- `endDate` → `end_date`
+- `expYears` → `exp_years`
+- `userId` → `user_id`
+- `skillId` → `skill_id`
 
 ---
 

--- a/backend/docs/MOCK_DATA_GUIDE.md
+++ b/backend/docs/MOCK_DATA_GUIDE.md
@@ -1,0 +1,202 @@
+# Mock Data 생성 가이드
+
+대량 Mock Data를 생성하여 테스트 환경을 구축하는 방법을 안내합니다.
+
+## 개요
+
+`backend/scripts/insert_mock_data.sql` 스크립트를 사용하여 실 서비스 사례를 고려한 비율로 약 13,000개 이상의 레코드를 생성할 수 있습니다.
+
+### 생성되는 데이터 규모
+
+| 도메인          | 레코드 수       | 비고                                       |
+| --------------- | --------------- | ------------------------------------------ |
+| Users           | 1,000명         | ADMIN 10명, PREMIUM 40명, USER 950명       |
+| Companies       | 150개           | 다양한 산업 분야                           |
+| Company Members | 150개           | 각 기업당 1명 관리자                       |
+| Job Postings    | 800개           | 기업당 평균 5-6개                          |
+| User Files      | 2,700개         | Resume 900, Portfolio 700, Education 1,100 |
+| Resumes         | 900개           | 각 사용자의 첫 번째 이력서는 기본값        |
+| Portfolios      | 700개           | 각 사용자의 첫 번째 포트폴리오는 기본값    |
+| Educations      | 1,100개         | 다양한 학력 정보                           |
+| User Careers    | 1,800개         | 사용자당 평균 1.8개 경력                   |
+| Applications    | 2,500개         | 사용자당 평균 2.5개 지원                   |
+| Bookmarks       | 2,000개         | 사용자당 평균 2개 북마크                   |
+| Company Likes   | 1,200개         | 사용자당 평균 1.2개 좋아요                 |
+| User Skills     | 2,500개         | 사용자당 평균 2.5개 스킬                   |
+| **총합**        | **약 13,000개** | Skills 제외                                |
+
+## 사전 준비
+
+### 1. Skills 데이터 확인
+
+`user_skills` 테이블에 데이터를 생성하기 위해서는 `skills` 테이블에 최소 1개 이상의 데이터가 있어야 합니다.
+
+```sql
+-- Skills 테이블 확인
+SELECT COUNT(*) FROM skills WHERE deleted_at IS NULL;
+```
+
+Skills 데이터가 없는 경우, 먼저 Skills를 생성해야 합니다. API를 통해 생성하거나 직접 SQL로 삽입할 수 있습니다.
+
+```sql
+-- 예시: 기본 Skills 데이터 삽입
+INSERT INTO skills (name, created_at, updated_at, deleted_at)
+VALUES
+    ('Java', NOW(), NOW(), NULL),
+    ('Python', NOW(), NOW(), NULL),
+    ('JavaScript', NOW(), NOW(), NULL),
+    ('Spring Boot', NOW(), NOW(), NULL),
+    ('React', NOW(), NOW(), NULL);
+```
+
+## 실행 방법
+
+### 방법 1: Docker 컨테이너를 통한 실행 (권장)
+
+Docker Compose로 실행 중인 MySQL 컨테이너에 직접 스크립트를 실행합니다.
+
+```bash
+# 프로젝트 루트 디렉토리에서 실행
+docker exec -i techeer-resume-mysql-1 mysql -uroot -proot techeer < backend/scripts/insert_mock_data.sql
+```
+
+**컨테이너 이름 확인:**
+
+```bash
+# 실행 중인 MySQL 컨테이너 확인
+docker ps | grep mysql
+```
+
+컨테이너 이름이 다른 경우, 위 명령어의 `techeer-resume-mysql-1` 부분을 실제 컨테이너 이름으로 변경하세요.
+
+### 방법 2: MySQL 클라이언트를 통한 실행
+
+로컬에 MySQL 클라이언트가 설치되어 있고, 데이터베이스에 직접 접근할 수 있는 경우:
+
+```bash
+# 프로젝트 루트 디렉토리에서 실행
+mysql -uroot -proot -h127.0.0.1 -P3306 techeer < backend/scripts/insert_mock_data.sql
+```
+
+**연결 정보가 다른 경우:**
+
+```bash
+# 호스트, 포트, 사용자명, 비밀번호, 데이터베이스명을 실제 값으로 변경
+mysql -u[사용자명] -p[비밀번호] -h[호스트] -P[포트] [데이터베이스명] < backend/scripts/insert_mock_data.sql
+```
+
+### 방법 3: MySQL 클라이언트에서 직접 실행
+
+MySQL 클라이언트(MySQL Workbench, DBeaver, TablePlus 등)에서 스크립트를 열어 직접 실행할 수 있습니다.
+
+1. MySQL 클라이언트에서 `techeer` 데이터베이스에 연결
+2. `backend/scripts/insert_mock_data.sql` 파일을 열기
+3. 전체 스크립트를 선택하여 실행
+
+## 실행 결과 확인
+
+스크립트 실행이 완료되면 자동으로 각 테이블의 레코드 수를 조회하는 통계 쿼리가 실행됩니다.
+
+```sql
+-- 수동으로 통계 확인 (스크립트 마지막 부분에 포함됨)
+SELECT
+    'Users' as table_name, COUNT(*) as record_count FROM users WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Companies', COUNT(*) FROM companies WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Company Members', COUNT(*) FROM company_members WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Job Postings', COUNT(*) FROM job_postings WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Applications', COUNT(*) FROM applications WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Bookmarks', COUNT(*) FROM bookmarks WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Company Likes', COUNT(*) FROM company_likes WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'User Careers', COUNT(*) FROM user_careers WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'User Skills', COUNT(*) FROM user_skills WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Resumes', COUNT(*) FROM resumes WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Portfolios', COUNT(*) FROM portfolios WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Educations', COUNT(*) FROM educations WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'User Files', COUNT(*) FROM user_files
+ORDER BY table_name;
+```
+
+## 주의사항
+
+### 1. 기존 데이터 보존
+
+스크립트는 기존 데이터를 삭제하지 않고 추가만 합니다. 하지만 다음 테이블의 경우 중복 방지 로직이 있어 일부 레코드가 생성되지 않을 수 있습니다:
+
+- `bookmarks` (user_id, jobposting_id 중복 방지)
+- `company_likes` (user_id, company_id 중복 방지)
+- `user_skills` (user_id, skill_id 중복 방지)
+
+### 2. 실행 시간
+
+대량 데이터 생성이므로 실행 시간이 다소 걸릴 수 있습니다 (약 1-2분).
+
+### 3. 외래키 제약 조건
+
+스크립트 실행 중에는 `FOREIGN_KEY_CHECKS`가 비활성화되어 있습니다. 실행 완료 후 자동으로 다시 활성화됩니다.
+
+### 4. 트랜잭션
+
+스크립트는 트랜잭션으로 묶여있지 않습니다. 중간에 오류가 발생하면 부분적으로 데이터가 생성될 수 있습니다. 필요시 수동으로 롤백하거나 데이터를 정리해야 합니다.
+
+## 문제 해결
+
+### 오류: "Table 'techeer.skills' doesn't exist"
+
+Skills 테이블이 없는 경우, 먼저 애플리케이션을 실행하여 테이블을 생성하거나 마이그레이션을 실행하세요.
+
+### 오류: "Duplicate entry for key"
+
+중복 방지 로직이 작동하여 일부 레코드가 생성되지 않을 수 있습니다. 이는 정상적인 동작입니다.
+
+### 오류: "Cannot add or update a child row: a foreign key constraint fails"
+
+외래키 제약 조건 오류가 발생한 경우:
+
+1. 스크립트가 올바른 순서로 실행되었는지 확인
+2. 참조되는 테이블에 데이터가 존재하는지 확인
+3. `FOREIGN_KEY_CHECKS`가 비활성화되어 있는지 확인
+
+## 데이터 초기화
+
+기존 데이터를 모두 삭제하고 새로 시작하려면:
+
+```sql
+-- 주의: 모든 데이터가 삭제됩니다!
+SET FOREIGN_KEY_CHECKS = 0;
+
+TRUNCATE TABLE user_skills;
+TRUNCATE TABLE educations;
+TRUNCATE TABLE portfolios;
+TRUNCATE TABLE resumes;
+TRUNCATE TABLE user_careers;
+TRUNCATE TABLE company_likes;
+TRUNCATE TABLE bookmarks;
+TRUNCATE TABLE applications;
+TRUNCATE TABLE job_postings;
+TRUNCATE TABLE company_members;
+TRUNCATE TABLE user_files;
+TRUNCATE TABLE companies;
+TRUNCATE TABLE users;
+
+SET FOREIGN_KEY_CHECKS = 1;
+```
+
+그 후 스크립트를 다시 실행하세요.
+
+## 추가 정보
+
+- 스크립트 파일 위치: `backend/scripts/insert_mock_data.sql`
+- 생성되는 데이터는 테스트 목적으로만 사용하세요
+- 프로덕션 환경에서는 절대 실행하지 마세요

--- a/backend/scripts/insert_mock_data.sql
+++ b/backend/scripts/insert_mock_data.sql
@@ -1,0 +1,511 @@
+-- ============================================
+-- 대량 Mock Data 생성 스크립트 (간소화 버전)
+-- 실 서비스 사례를 고려한 비율로 데이터 생성
+-- 총 약 12,800개 이상의 레코드 생성
+-- ============================================
+
+SET FOREIGN_KEY_CHECKS = 0;
+SET SQL_MODE = 'NO_AUTO_VALUE_ON_ZERO';
+
+-- ============================================
+-- 1. Users (사용자) - 1000명
+-- ============================================
+INSERT INTO users (email, name, password, refresh_token, role, social_type, created_at, updated_at, deleted_at)
+SELECT 
+    CONCAT('user', n, '@example.com') as email,
+    CONCAT('사용자', n) as name,
+    '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6Z5EHsM8lE9lBOsl7iwK8pJZO' as password,
+    NULL as refresh_token,
+    CASE 
+        WHEN n <= 10 THEN 'ADMIN'
+        WHEN n <= 50 THEN 'PREMIUM'
+        ELSE 'USER'
+    END as role,
+    CASE 
+        WHEN n % 5 = 0 THEN 'LOCAL'
+        WHEN n % 5 = 1 THEN 'GITHUB'
+        WHEN n % 5 = 2 THEN 'GOOGLE'
+        WHEN n % 5 = 3 THEN 'KAKAO'
+        ELSE 'LINKEDIN'
+    END as social_type,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+         (SELECT @row := 0) r
+    LIMIT 1000
+) numbers;
+
+-- ============================================
+-- 2. Companies (기업) - 150개
+-- ============================================
+INSERT INTO companies (name, industry_domain, website_url, location, created_at, updated_at, deleted_at)
+SELECT 
+    CONCAT('기업', n) as name,
+    CASE 
+        WHEN n % 10 = 0 THEN 'IT/소프트웨어'
+        WHEN n % 10 = 1 THEN '금융/보험'
+        WHEN n % 10 = 2 THEN '제조업'
+        WHEN n % 10 = 3 THEN '유통/물류'
+        WHEN n % 10 = 4 THEN '건설/부동산'
+        WHEN n % 10 = 5 THEN '의료/바이오'
+        WHEN n % 10 = 6 THEN '교육'
+        WHEN n % 10 = 7 THEN '미디어/엔터테인먼트'
+        WHEN n % 10 = 8 THEN '서비스업'
+        ELSE '기타'
+    END as industry_domain,
+    CONCAT('https://company', n, '.com') as website_url,
+    CASE 
+        WHEN n % 5 = 0 THEN '서울특별시'
+        WHEN n % 5 = 1 THEN '경기도'
+        WHEN n % 5 = 2 THEN '부산광역시'
+        WHEN n % 5 = 3 THEN '인천광역시'
+        ELSE '대전광역시'
+    END as location,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 730) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT @row := 0) r
+    LIMIT 150
+) numbers;
+
+-- ============================================
+-- 3. Company Members (기업 멤버) - 150개
+-- ============================================
+INSERT INTO company_members (user_id, company_id, role, status, created_at, updated_at, deleted_at)
+SELECT 
+    n as user_id,
+    n as company_id,
+    'ADMIN' as role,
+    'ACTIVE' as status,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT @row := 0) r
+    LIMIT 150
+) numbers
+WHERE n <= (SELECT COUNT(*) FROM companies);
+
+-- ============================================
+-- 4. Job Postings (채용공고) - 800개
+-- ============================================
+INSERT INTO job_postings (company_id, title, contents, exp_years, source_type, origin_url, status, created_at, updated_at, deleted_at)
+SELECT 
+    FLOOR(1 + RAND() * (SELECT COUNT(*) FROM companies)) as company_id,
+    CASE 
+        WHEN n % 20 = 0 THEN CONCAT('백엔드 개발자 채용 (', n, ')')
+        WHEN n % 20 = 1 THEN CONCAT('프론트엔드 개발자 채용 (', n, ')')
+        WHEN n % 20 = 2 THEN CONCAT('풀스택 개발자 채용 (', n, ')')
+        WHEN n % 20 = 3 THEN CONCAT('데이터 엔지니어 채용 (', n, ')')
+        WHEN n % 20 = 4 THEN CONCAT('DevOps 엔지니어 채용 (', n, ')')
+        WHEN n % 20 = 5 THEN CONCAT('iOS 개발자 채용 (', n, ')')
+        WHEN n % 20 = 6 THEN CONCAT('Android 개발자 채용 (', n, ')')
+        WHEN n % 20 = 7 THEN CONCAT('QA 엔지니어 채용 (', n, ')')
+        WHEN n % 20 = 8 THEN CONCAT('프로덕트 매니저 채용 (', n, ')')
+        WHEN n % 20 = 9 THEN CONCAT('UI/UX 디자이너 채용 (', n, ')')
+        WHEN n % 20 = 10 THEN CONCAT('마케팅 매니저 채용 (', n, ')')
+        WHEN n % 20 = 11 THEN CONCAT('영업 매니저 채용 (', n, ')')
+        WHEN n % 20 = 12 THEN CONCAT('인사 담당자 채용 (', n, ')')
+        WHEN n % 20 = 13 THEN CONCAT('재무 담당자 채용 (', n, ')')
+        WHEN n % 20 = 14 THEN CONCAT('기획자 채용 (', n, ')')
+        WHEN n % 20 = 15 THEN CONCAT('시니어 개발자 채용 (', n, ')')
+        WHEN n % 20 = 16 THEN CONCAT('주니어 개발자 채용 (', n, ')')
+        WHEN n % 20 = 17 THEN CONCAT('시스템 엔지니어 채용 (', n, ')')
+        WHEN n % 20 = 18 THEN CONCAT('보안 엔지니어 채용 (', n, ')')
+        ELSE CONCAT('소프트웨어 엔지니어 채용 (', n, ')')
+    END as title,
+    CONCAT('우리 회사는 최고의 인재를 찾고 있습니다.\n',
+           '주요 업무:\n',
+           '- 신규 서비스 개발 및 운영\n',
+           '- 기존 시스템 개선 및 최적화\n',
+           '- 팀원들과의 협업\n\n',
+           '자격 요건:\n',
+           '- 관련 경력 ', FLOOR(1 + RAND() * 5), '년 이상\n',
+           '- ', CASE WHEN n % 2 = 0 THEN 'Java' ELSE 'Python' END, ' 개발 경험\n',
+           '- 협업 능력 및 소통 능력\n\n',
+           '우대 사항:\n',
+           '- 대규모 서비스 개발 경험\n',
+           '- 클라우드 인프라 경험') as contents,
+    FLOOR(RAND() * 7) as exp_years,
+    CASE WHEN n % 3 = 0 THEN 'CRAWLED' ELSE 'DIRECT' END as source_type,
+    CASE WHEN n % 3 = 0 THEN CONCAT('https://external-job-site.com/job/', n) ELSE NULL END as origin_url,
+    CASE WHEN n % 10 = 0 THEN 'CLOSED' ELSE 'OPEN' END as status,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 180) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+         (SELECT @row := 0) r
+    LIMIT 800
+) numbers;
+
+-- ============================================
+-- 5. User Files (사용자 파일) - 2700개
+-- ============================================
+-- Resume Files (900개)
+INSERT INTO user_files (user_id, category, uuid, file_url, file_type, original_name, created_at)
+SELECT 
+    FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+    'RESUME' as category,
+    REPLACE(UUID(), '-', '') as uuid,
+    CONCAT('https://storage.googleapis.com/bucket/resume/resume_', n, '.pdf') as file_url,
+    'PDF' as file_type,
+    CONCAT('이력서_', n, '.pdf') as original_name,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT @row := 0) r
+    LIMIT 900
+) numbers;
+
+-- Portfolio Files (700개)
+INSERT INTO user_files (user_id, category, uuid, file_url, file_type, original_name, created_at)
+SELECT 
+    FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+    'PORTFOLIO' as category,
+    REPLACE(UUID(), '-', '') as uuid,
+    CONCAT('https://storage.googleapis.com/bucket/portfolio/portfolio_', n, '.pdf') as file_url,
+    'PDF' as file_type,
+    CONCAT('포트폴리오_', n, '.pdf') as original_name,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT @row := 0) r
+    LIMIT 700
+) numbers;
+
+-- Education Files (1100개)
+INSERT INTO user_files (user_id, category, uuid, file_url, file_type, original_name, created_at)
+SELECT 
+    FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+    'EDUCATION' as category,
+    REPLACE(UUID(), '-', '') as uuid,
+    CONCAT('https://storage.googleapis.com/bucket/education/education_', n, '.pdf') as file_url,
+    'PDF' as file_type,
+    CONCAT('학력증명서_', n, '.pdf') as original_name,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT @row := 0) r
+    LIMIT 1100
+) numbers;
+
+-- ============================================
+-- 6. Resumes (이력서) - 900개
+-- ============================================
+INSERT INTO resumes (file_id, title, is_default, created_at, updated_at, deleted_at)
+SELECT 
+    uf.file_id,
+    CONCAT('이력서_', uf.file_id) as title,
+    FALSE as is_default,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM user_files uf
+WHERE uf.category = 'RESUME'
+LIMIT 900;
+
+-- 각 사용자의 첫 번째 이력서를 기본으로 설정
+UPDATE resumes r
+INNER JOIN (
+    SELECT MIN(resume_id) as first_resume_id, file_id
+    FROM resumes
+    GROUP BY file_id
+) first ON r.resume_id = first.first_resume_id
+SET r.is_default = TRUE
+WHERE r.resume_id IN (
+    SELECT resume_id FROM (
+        SELECT r2.resume_id
+        FROM resumes r2
+        INNER JOIN user_files uf ON r2.file_id = uf.file_id
+        WHERE uf.category = 'RESUME'
+        GROUP BY uf.user_id
+        HAVING MIN(r2.resume_id)
+    ) sub
+);
+
+-- ============================================
+-- 7. Portfolios (포트폴리오) - 700개
+-- ============================================
+INSERT INTO portfolios (file_id, title, is_default, created_at, updated_at, deleted_at)
+SELECT 
+    uf.file_id,
+    CONCAT('포트폴리오_', uf.file_id) as title,
+    FALSE as is_default,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM user_files uf
+WHERE uf.category = 'PORTFOLIO'
+LIMIT 700;
+
+-- 각 사용자의 첫 번째 포트폴리오를 기본으로 설정
+UPDATE portfolios p
+INNER JOIN (
+    SELECT MIN(portfolio_id) as first_portfolio_id, file_id
+    FROM portfolios
+    GROUP BY file_id
+) first ON p.portfolio_id = first.first_portfolio_id
+SET p.is_default = TRUE
+WHERE p.portfolio_id IN (
+    SELECT portfolio_id FROM (
+        SELECT p2.portfolio_id
+        FROM portfolios p2
+        INNER JOIN user_files uf ON p2.file_id = uf.file_id
+        WHERE uf.category = 'PORTFOLIO'
+        GROUP BY uf.user_id
+        HAVING MIN(p2.portfolio_id)
+    ) sub
+);
+
+-- ============================================
+-- 8. Educations (학력) - 1100개
+-- ============================================
+INSERT INTO educations (file_id, title, is_default, created_at, updated_at, deleted_at)
+SELECT 
+    uf.file_id,
+    CASE 
+        WHEN n % 4 = 0 THEN '고등학교 졸업'
+        WHEN n % 4 = 1 THEN '전문대학 졸업'
+        WHEN n % 4 = 2 THEN '대학교 졸업'
+        ELSE '대학원 졸업'
+    END as title,
+    CASE WHEN n % 2 = 0 THEN TRUE ELSE FALSE END as is_default,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM user_files uf
+CROSS JOIN (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT @row := 0) r
+    LIMIT 1100
+) numbers
+WHERE uf.category = 'EDUCATION'
+LIMIT 1100;
+
+-- ============================================
+-- 9. User Careers (경력) - 1800개
+-- ============================================
+INSERT INTO user_careers (user_id, file_id, company_id, company_name, job_title, is_current, start_date, end_date, created_at, updated_at, deleted_at)
+SELECT 
+    FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+    NULL as file_id,
+    CASE WHEN n % 3 = 0 THEN FLOOR(1 + RAND() * (SELECT COUNT(*) FROM companies)) ELSE NULL END as company_id,
+    CASE 
+        WHEN n % 10 = 0 THEN '네이버'
+        WHEN n % 10 = 1 THEN '카카오'
+        WHEN n % 10 = 2 THEN '삼성전자'
+        WHEN n % 10 = 3 THEN 'LG전자'
+        WHEN n % 10 = 4 THEN 'SK하이닉스'
+        WHEN n % 10 = 5 THEN '현대자동차'
+        WHEN n % 10 = 6 THEN '토스'
+        WHEN n % 10 = 7 THEN '당근마켓'
+        WHEN n % 10 = 8 THEN '쿠팡'
+        ELSE CONCAT('기업', FLOOR(1 + RAND() * 100))
+    END as company_name,
+    CASE 
+        WHEN n % 8 = 0 THEN '백엔드 개발자'
+        WHEN n % 8 = 1 THEN '프론트엔드 개발자'
+        WHEN n % 8 = 2 THEN '풀스택 개발자'
+        WHEN n % 8 = 3 THEN '데이터 엔지니어'
+        WHEN n % 8 = 4 THEN 'DevOps 엔지니어'
+        WHEN n % 8 = 5 THEN '시니어 개발자'
+        WHEN n % 8 = 6 THEN '주니어 개발자'
+        ELSE '소프트웨어 엔지니어'
+    END as job_title,
+    CASE WHEN n % 3 = 0 THEN TRUE ELSE FALSE END as is_current,
+    DATE_SUB(NOW(), INTERVAL FLOOR(365 + RAND() * 1825) DAY) as start_date,
+    CASE 
+        WHEN n % 3 = 0 THEN NULL
+        ELSE DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY)
+    END as end_date,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+         (SELECT @row := 0) r
+    LIMIT 1800
+) numbers;
+
+-- ============================================
+-- 10. Applications (지원) - 2500개
+-- ============================================
+INSERT INTO applications (user_id, jobposting_id, status, created_at, updated_at, deleted_at)
+SELECT 
+    FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+    FLOOR(1 + RAND() * (SELECT COUNT(*) FROM job_postings)) as jobposting_id,
+    CASE 
+        WHEN n % 10 = 0 THEN 'APPLIED'
+        WHEN n % 10 = 1 THEN 'VIEWED'
+        WHEN n % 10 = 2 THEN 'PASSED'
+        WHEN n % 10 = 3 THEN 'REJECTED'
+        WHEN n % 10 = 4 THEN 'APPLIED'
+        WHEN n % 10 = 5 THEN 'VIEWED'
+        WHEN n % 10 = 6 THEN 'APPLIED'
+        WHEN n % 10 = 7 THEN 'VIEWED'
+        WHEN n % 10 = 8 THEN 'PASSED'
+        ELSE 'APPLIED'
+    END as status,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 90) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+         (SELECT @row := 0) r
+    LIMIT 2500
+) numbers;
+
+-- ============================================
+-- 11. Bookmarks (북마크) - 2000개
+-- ============================================
+INSERT INTO bookmarks (user_id, jobposting_id, created_at, updated_at, deleted_at)
+SELECT 
+    user_id,
+    jobposting_id,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 180) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT DISTINCT
+        FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+        FLOOR(1 + RAND() * (SELECT COUNT(*) FROM job_postings)) as jobposting_id
+    FROM (
+        SELECT @row := @row + 1 as n
+        FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+             (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+             (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+             (SELECT @row := 0) r
+        LIMIT 2500
+    ) numbers
+) unique_pairs
+WHERE NOT EXISTS (
+    SELECT 1 FROM bookmarks b 
+    WHERE b.user_id = unique_pairs.user_id
+      AND b.jobposting_id = unique_pairs.jobposting_id
+)
+LIMIT 2000;
+
+-- ============================================
+-- 12. Company Likes (기업 좋아요) - 1200개
+-- ============================================
+INSERT INTO company_likes (user_id, company_id, created_at, updated_at, deleted_at)
+SELECT 
+    user_id,
+    company_id,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT DISTINCT
+        FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+        FLOOR(1 + RAND() * (SELECT COUNT(*) FROM companies)) as company_id
+    FROM (
+        SELECT @row := @row + 1 as n
+        FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+             (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+             (SELECT @row := 0) r
+        LIMIT 1500
+    ) numbers
+) unique_pairs
+WHERE NOT EXISTS (
+    SELECT 1 FROM company_likes cl 
+    WHERE cl.user_id = unique_pairs.user_id
+      AND cl.company_id = unique_pairs.company_id
+)
+LIMIT 1200;
+
+-- ============================================
+-- 13. User Skills (사용자 스킬) - 2500개
+-- Skill이 먼저 생성되어 있어야 함
+-- ============================================
+INSERT INTO user_skills (user_id, skill_id, created_at, updated_at, deleted_at)
+SELECT 
+    user_id,
+    skill_id,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT DISTINCT
+        FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+        (SELECT skill_id FROM skills WHERE deleted_at IS NULL ORDER BY RAND() LIMIT 1) as skill_id
+    FROM (
+        SELECT @row := @row + 1 as n
+        FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+             (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+             (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+             (SELECT @row := 0) r
+        LIMIT 3000
+    ) numbers
+    WHERE EXISTS (SELECT 1 FROM skills WHERE deleted_at IS NULL)
+) unique_pairs
+WHERE NOT EXISTS (
+    SELECT 1 FROM user_skills us 
+    WHERE us.user_id = unique_pairs.user_id
+      AND us.skill_id = unique_pairs.skill_id
+)
+LIMIT 2500;
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+-- ============================================
+-- 데이터 생성 완료 통계
+-- ============================================
+SELECT 
+    'Users' as table_name, COUNT(*) as record_count FROM users WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Companies', COUNT(*) FROM companies WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Company Members', COUNT(*) FROM company_members WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Job Postings', COUNT(*) FROM job_postings WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Applications', COUNT(*) FROM applications WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Bookmarks', COUNT(*) FROM bookmarks WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Company Likes', COUNT(*) FROM company_likes WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'User Careers', COUNT(*) FROM user_careers WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'User Skills', COUNT(*) FROM user_skills WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Resumes', COUNT(*) FROM resumes WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Portfolios', COUNT(*) FROM portfolios WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Educations', COUNT(*) FROM educations WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'User Files', COUNT(*) FROM user_files
+ORDER BY table_name;
+

--- a/backend/scripts/insert_mock_data_simple.sql
+++ b/backend/scripts/insert_mock_data_simple.sql
@@ -1,0 +1,511 @@
+-- ============================================
+-- 대량 Mock Data 생성 스크립트 (간소화 버전)
+-- 실 서비스 사례를 고려한 비율로 데이터 생성
+-- 총 약 12,800개 이상의 레코드 생성
+-- ============================================
+
+SET FOREIGN_KEY_CHECKS = 0;
+SET SQL_MODE = 'NO_AUTO_VALUE_ON_ZERO';
+
+-- ============================================
+-- 1. Users (사용자) - 1000명
+-- ============================================
+INSERT INTO users (email, name, password, refresh_token, role, social_type, created_at, updated_at, deleted_at)
+SELECT 
+    CONCAT('user', n, '@example.com') as email,
+    CONCAT('사용자', n) as name,
+    '$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6Z5EHsM8lE9lBOsl7iwK8pJZO' as password,
+    NULL as refresh_token,
+    CASE 
+        WHEN n <= 10 THEN 'ADMIN'
+        WHEN n <= 50 THEN 'PREMIUM'
+        ELSE 'USER'
+    END as role,
+    CASE 
+        WHEN n % 5 = 0 THEN 'LOCAL'
+        WHEN n % 5 = 1 THEN 'GITHUB'
+        WHEN n % 5 = 2 THEN 'GOOGLE'
+        WHEN n % 5 = 3 THEN 'KAKAO'
+        ELSE 'LINKEDIN'
+    END as social_type,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+         (SELECT @row := 0) r
+    LIMIT 1000
+) numbers;
+
+-- ============================================
+-- 2. Companies (기업) - 150개
+-- ============================================
+INSERT INTO companies (name, industry_domain, website_url, location, created_at, updated_at, deleted_at)
+SELECT 
+    CONCAT('기업', n) as name,
+    CASE 
+        WHEN n % 10 = 0 THEN 'IT/소프트웨어'
+        WHEN n % 10 = 1 THEN '금융/보험'
+        WHEN n % 10 = 2 THEN '제조업'
+        WHEN n % 10 = 3 THEN '유통/물류'
+        WHEN n % 10 = 4 THEN '건설/부동산'
+        WHEN n % 10 = 5 THEN '의료/바이오'
+        WHEN n % 10 = 6 THEN '교육'
+        WHEN n % 10 = 7 THEN '미디어/엔터테인먼트'
+        WHEN n % 10 = 8 THEN '서비스업'
+        ELSE '기타'
+    END as industry_domain,
+    CONCAT('https://company', n, '.com') as website_url,
+    CASE 
+        WHEN n % 5 = 0 THEN '서울특별시'
+        WHEN n % 5 = 1 THEN '경기도'
+        WHEN n % 5 = 2 THEN '부산광역시'
+        WHEN n % 5 = 3 THEN '인천광역시'
+        ELSE '대전광역시'
+    END as location,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 730) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT @row := 0) r
+    LIMIT 150
+) numbers;
+
+-- ============================================
+-- 3. Company Members (기업 멤버) - 150개
+-- ============================================
+INSERT INTO company_members (user_id, company_id, role, status, created_at, updated_at, deleted_at)
+SELECT 
+    n as user_id,
+    n as company_id,
+    'ADMIN' as role,
+    'ACTIVE' as status,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT @row := 0) r
+    LIMIT 150
+) numbers
+WHERE n <= (SELECT COUNT(*) FROM companies);
+
+-- ============================================
+-- 4. Job Postings (채용공고) - 800개
+-- ============================================
+INSERT INTO job_postings (company_id, title, contents, exp_years, source_type, origin_url, status, created_at, updated_at, deleted_at)
+SELECT 
+    FLOOR(1 + RAND() * (SELECT COUNT(*) FROM companies)) as company_id,
+    CASE 
+        WHEN n % 20 = 0 THEN CONCAT('백엔드 개발자 채용 (', n, ')')
+        WHEN n % 20 = 1 THEN CONCAT('프론트엔드 개발자 채용 (', n, ')')
+        WHEN n % 20 = 2 THEN CONCAT('풀스택 개발자 채용 (', n, ')')
+        WHEN n % 20 = 3 THEN CONCAT('데이터 엔지니어 채용 (', n, ')')
+        WHEN n % 20 = 4 THEN CONCAT('DevOps 엔지니어 채용 (', n, ')')
+        WHEN n % 20 = 5 THEN CONCAT('iOS 개발자 채용 (', n, ')')
+        WHEN n % 20 = 6 THEN CONCAT('Android 개발자 채용 (', n, ')')
+        WHEN n % 20 = 7 THEN CONCAT('QA 엔지니어 채용 (', n, ')')
+        WHEN n % 20 = 8 THEN CONCAT('프로덕트 매니저 채용 (', n, ')')
+        WHEN n % 20 = 9 THEN CONCAT('UI/UX 디자이너 채용 (', n, ')')
+        WHEN n % 20 = 10 THEN CONCAT('마케팅 매니저 채용 (', n, ')')
+        WHEN n % 20 = 11 THEN CONCAT('영업 매니저 채용 (', n, ')')
+        WHEN n % 20 = 12 THEN CONCAT('인사 담당자 채용 (', n, ')')
+        WHEN n % 20 = 13 THEN CONCAT('재무 담당자 채용 (', n, ')')
+        WHEN n % 20 = 14 THEN CONCAT('기획자 채용 (', n, ')')
+        WHEN n % 20 = 15 THEN CONCAT('시니어 개발자 채용 (', n, ')')
+        WHEN n % 20 = 16 THEN CONCAT('주니어 개발자 채용 (', n, ')')
+        WHEN n % 20 = 17 THEN CONCAT('시스템 엔지니어 채용 (', n, ')')
+        WHEN n % 20 = 18 THEN CONCAT('보안 엔지니어 채용 (', n, ')')
+        ELSE CONCAT('소프트웨어 엔지니어 채용 (', n, ')')
+    END as title,
+    CONCAT('우리 회사는 최고의 인재를 찾고 있습니다.\n',
+           '주요 업무:\n',
+           '- 신규 서비스 개발 및 운영\n',
+           '- 기존 시스템 개선 및 최적화\n',
+           '- 팀원들과의 협업\n\n',
+           '자격 요건:\n',
+           '- 관련 경력 ', FLOOR(1 + RAND() * 5), '년 이상\n',
+           '- ', CASE WHEN n % 2 = 0 THEN 'Java' ELSE 'Python' END, ' 개발 경험\n',
+           '- 협업 능력 및 소통 능력\n\n',
+           '우대 사항:\n',
+           '- 대규모 서비스 개발 경험\n',
+           '- 클라우드 인프라 경험') as contents,
+    FLOOR(RAND() * 7) as exp_years,
+    CASE WHEN n % 3 = 0 THEN 'CRAWLED' ELSE 'DIRECT' END as source_type,
+    CASE WHEN n % 3 = 0 THEN CONCAT('https://external-job-site.com/job/', n) ELSE NULL END as origin_url,
+    CASE WHEN n % 10 = 0 THEN 'CLOSED' ELSE 'OPEN' END as status,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 180) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+         (SELECT @row := 0) r
+    LIMIT 800
+) numbers;
+
+-- ============================================
+-- 5. User Files (사용자 파일) - 2700개
+-- ============================================
+-- Resume Files (900개)
+INSERT INTO user_files (user_id, category, uuid, file_url, file_type, original_name, created_at)
+SELECT 
+    FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+    'RESUME' as category,
+    REPLACE(UUID(), '-', '') as uuid,
+    CONCAT('https://storage.googleapis.com/bucket/resume/resume_', n, '.pdf') as file_url,
+    'PDF' as file_type,
+    CONCAT('이력서_', n, '.pdf') as original_name,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT @row := 0) r
+    LIMIT 900
+) numbers;
+
+-- Portfolio Files (700개)
+INSERT INTO user_files (user_id, category, uuid, file_url, file_type, original_name, created_at)
+SELECT 
+    FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+    'PORTFOLIO' as category,
+    REPLACE(UUID(), '-', '') as uuid,
+    CONCAT('https://storage.googleapis.com/bucket/portfolio/portfolio_', n, '.pdf') as file_url,
+    'PDF' as file_type,
+    CONCAT('포트폴리오_', n, '.pdf') as original_name,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT @row := 0) r
+    LIMIT 700
+) numbers;
+
+-- Education Files (1100개)
+INSERT INTO user_files (user_id, category, uuid, file_url, file_type, original_name, created_at)
+SELECT 
+    FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+    'EDUCATION' as category,
+    REPLACE(UUID(), '-', '') as uuid,
+    CONCAT('https://storage.googleapis.com/bucket/education/education_', n, '.pdf') as file_url,
+    'PDF' as file_type,
+    CONCAT('학력증명서_', n, '.pdf') as original_name,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT @row := 0) r
+    LIMIT 1100
+) numbers;
+
+-- ============================================
+-- 6. Resumes (이력서) - 900개
+-- ============================================
+INSERT INTO resumes (file_id, title, is_default, created_at, updated_at, deleted_at)
+SELECT 
+    uf.file_id,
+    CONCAT('이력서_', uf.file_id) as title,
+    FALSE as is_default,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM user_files uf
+WHERE uf.category = 'RESUME'
+LIMIT 900;
+
+-- 각 사용자의 첫 번째 이력서를 기본으로 설정
+UPDATE resumes r
+INNER JOIN (
+    SELECT MIN(resume_id) as first_resume_id, file_id
+    FROM resumes
+    GROUP BY file_id
+) first ON r.resume_id = first.first_resume_id
+SET r.is_default = TRUE
+WHERE r.resume_id IN (
+    SELECT resume_id FROM (
+        SELECT r2.resume_id
+        FROM resumes r2
+        INNER JOIN user_files uf ON r2.file_id = uf.file_id
+        WHERE uf.category = 'RESUME'
+        GROUP BY uf.user_id
+        HAVING MIN(r2.resume_id)
+    ) sub
+);
+
+-- ============================================
+-- 7. Portfolios (포트폴리오) - 700개
+-- ============================================
+INSERT INTO portfolios (file_id, title, is_default, created_at, updated_at, deleted_at)
+SELECT 
+    uf.file_id,
+    CONCAT('포트폴리오_', uf.file_id) as title,
+    FALSE as is_default,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM user_files uf
+WHERE uf.category = 'PORTFOLIO'
+LIMIT 700;
+
+-- 각 사용자의 첫 번째 포트폴리오를 기본으로 설정
+UPDATE portfolios p
+INNER JOIN (
+    SELECT MIN(portfolio_id) as first_portfolio_id, file_id
+    FROM portfolios
+    GROUP BY file_id
+) first ON p.portfolio_id = first.first_portfolio_id
+SET p.is_default = TRUE
+WHERE p.portfolio_id IN (
+    SELECT portfolio_id FROM (
+        SELECT p2.portfolio_id
+        FROM portfolios p2
+        INNER JOIN user_files uf ON p2.file_id = uf.file_id
+        WHERE uf.category = 'PORTFOLIO'
+        GROUP BY uf.user_id
+        HAVING MIN(p2.portfolio_id)
+    ) sub
+);
+
+-- ============================================
+-- 8. Educations (학력) - 1100개
+-- ============================================
+INSERT INTO educations (file_id, title, is_default, created_at, updated_at, deleted_at)
+SELECT 
+    uf.file_id,
+    CASE 
+        WHEN n % 4 = 0 THEN '고등학교 졸업'
+        WHEN n % 4 = 1 THEN '전문대학 졸업'
+        WHEN n % 4 = 2 THEN '대학교 졸업'
+        ELSE '대학원 졸업'
+    END as title,
+    CASE WHEN n % 2 = 0 THEN TRUE ELSE FALSE END as is_default,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM user_files uf
+CROSS JOIN (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT @row := 0) r
+    LIMIT 1100
+) numbers
+WHERE uf.category = 'EDUCATION'
+LIMIT 1100;
+
+-- ============================================
+-- 9. User Careers (경력) - 1800개
+-- ============================================
+INSERT INTO user_careers (user_id, file_id, company_id, company_name, job_title, is_current, start_date, end_date, created_at, updated_at, deleted_at)
+SELECT 
+    FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+    NULL as file_id,
+    CASE WHEN n % 3 = 0 THEN FLOOR(1 + RAND() * (SELECT COUNT(*) FROM companies)) ELSE NULL END as company_id,
+    CASE 
+        WHEN n % 10 = 0 THEN '네이버'
+        WHEN n % 10 = 1 THEN '카카오'
+        WHEN n % 10 = 2 THEN '삼성전자'
+        WHEN n % 10 = 3 THEN 'LG전자'
+        WHEN n % 10 = 4 THEN 'SK하이닉스'
+        WHEN n % 10 = 5 THEN '현대자동차'
+        WHEN n % 10 = 6 THEN '토스'
+        WHEN n % 10 = 7 THEN '당근마켓'
+        WHEN n % 10 = 8 THEN '쿠팡'
+        ELSE CONCAT('기업', FLOOR(1 + RAND() * 100))
+    END as company_name,
+    CASE 
+        WHEN n % 8 = 0 THEN '백엔드 개발자'
+        WHEN n % 8 = 1 THEN '프론트엔드 개발자'
+        WHEN n % 8 = 2 THEN '풀스택 개발자'
+        WHEN n % 8 = 3 THEN '데이터 엔지니어'
+        WHEN n % 8 = 4 THEN 'DevOps 엔지니어'
+        WHEN n % 8 = 5 THEN '시니어 개발자'
+        WHEN n % 8 = 6 THEN '주니어 개발자'
+        ELSE '소프트웨어 엔지니어'
+    END as job_title,
+    CASE WHEN n % 3 = 0 THEN TRUE ELSE FALSE END as is_current,
+    DATE_SUB(NOW(), INTERVAL FLOOR(365 + RAND() * 1825) DAY) as start_date,
+    CASE 
+        WHEN n % 3 = 0 THEN NULL
+        ELSE DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY)
+    END as end_date,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+         (SELECT @row := 0) r
+    LIMIT 1800
+) numbers;
+
+-- ============================================
+-- 10. Applications (지원) - 2500개
+-- ============================================
+INSERT INTO applications (user_id, jobposting_id, status, created_at, updated_at, deleted_at)
+SELECT 
+    FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+    FLOOR(1 + RAND() * (SELECT COUNT(*) FROM job_postings)) as jobposting_id,
+    CASE 
+        WHEN n % 10 = 0 THEN 'APPLIED'
+        WHEN n % 10 = 1 THEN 'VIEWED'
+        WHEN n % 10 = 2 THEN 'PASSED'
+        WHEN n % 10 = 3 THEN 'REJECTED'
+        WHEN n % 10 = 4 THEN 'APPLIED'
+        WHEN n % 10 = 5 THEN 'VIEWED'
+        WHEN n % 10 = 6 THEN 'APPLIED'
+        WHEN n % 10 = 7 THEN 'VIEWED'
+        WHEN n % 10 = 8 THEN 'PASSED'
+        ELSE 'APPLIED'
+    END as status,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 90) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+         (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+         (SELECT @row := 0) r
+    LIMIT 2500
+) numbers;
+
+-- ============================================
+-- 11. Bookmarks (북마크) - 2000개
+-- ============================================
+INSERT INTO bookmarks (user_id, jobposting_id, created_at, updated_at, deleted_at)
+SELECT 
+    user_id,
+    jobposting_id,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 180) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT DISTINCT
+        FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+        FLOOR(1 + RAND() * (SELECT COUNT(*) FROM job_postings)) as jobposting_id
+    FROM (
+        SELECT @row := @row + 1 as n
+        FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+             (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+             (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+             (SELECT @row := 0) r
+        LIMIT 2500
+    ) numbers
+) unique_pairs
+WHERE NOT EXISTS (
+    SELECT 1 FROM bookmarks b 
+    WHERE b.user_id = unique_pairs.user_id
+      AND b.jobposting_id = unique_pairs.jobposting_id
+)
+LIMIT 2000;
+
+-- ============================================
+-- 12. Company Likes (기업 좋아요) - 1200개
+-- ============================================
+INSERT INTO company_likes (user_id, company_id, created_at, updated_at, deleted_at)
+SELECT 
+    user_id,
+    company_id,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT DISTINCT
+        FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+        FLOOR(1 + RAND() * (SELECT COUNT(*) FROM companies)) as company_id
+    FROM (
+        SELECT @row := @row + 1 as n
+        FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+             (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+             (SELECT @row := 0) r
+        LIMIT 1500
+    ) numbers
+) unique_pairs
+WHERE NOT EXISTS (
+    SELECT 1 FROM company_likes cl 
+    WHERE cl.user_id = unique_pairs.user_id
+      AND cl.company_id = unique_pairs.company_id
+)
+LIMIT 1200;
+
+-- ============================================
+-- 13. User Skills (사용자 스킬) - 2500개
+-- Skill이 먼저 생성되어 있어야 함
+-- ============================================
+INSERT INTO user_skills (user_id, skill_id, created_at, updated_at, deleted_at)
+SELECT 
+    user_id,
+    skill_id,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 365) DAY) as created_at,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 30) DAY) as updated_at,
+    NULL as deleted_at
+FROM (
+    SELECT DISTINCT
+        FLOOR(1 + RAND() * (SELECT COUNT(*) FROM users)) as user_id,
+        (SELECT skill_id FROM skills WHERE deleted_at IS NULL ORDER BY RAND() LIMIT 1) as skill_id
+    FROM (
+        SELECT @row := @row + 1 as n
+        FROM (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+             (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+             (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t3,
+             (SELECT @row := 0) r
+        LIMIT 3000
+    ) numbers
+    WHERE EXISTS (SELECT 1 FROM skills WHERE deleted_at IS NULL)
+) unique_pairs
+WHERE NOT EXISTS (
+    SELECT 1 FROM user_skills us 
+    WHERE us.user_id = unique_pairs.user_id
+      AND us.skill_id = unique_pairs.skill_id
+)
+LIMIT 2500;
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+-- ============================================
+-- 데이터 생성 완료 통계
+-- ============================================
+SELECT 
+    'Users' as table_name, COUNT(*) as record_count FROM users WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Companies', COUNT(*) FROM companies WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Company Members', COUNT(*) FROM company_members WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Job Postings', COUNT(*) FROM job_postings WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Applications', COUNT(*) FROM applications WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Bookmarks', COUNT(*) FROM bookmarks WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Company Likes', COUNT(*) FROM company_likes WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'User Careers', COUNT(*) FROM user_careers WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'User Skills', COUNT(*) FROM user_skills WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Resumes', COUNT(*) FROM resumes WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Portfolios', COUNT(*) FROM portfolios WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'Educations', COUNT(*) FROM educations WHERE deleted_at IS NULL
+UNION ALL
+SELECT 'User Files', COUNT(*) FROM user_files
+ORDER BY table_name;
+

--- a/backend/src/main/java/com/techeer/backend/api/application/adapter/in/web/ApplicationController.java
+++ b/backend/src/main/java/com/techeer/backend/api/application/adapter/in/web/ApplicationController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Application", description = "지원 API")

--- a/backend/src/main/java/com/techeer/backend/api/application/adapter/out/persistence/ApplicationJpaRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/application/adapter/out/persistence/ApplicationJpaRepository.java
@@ -3,12 +3,11 @@ package com.techeer.backend.api.application.adapter.out.persistence;
 import com.techeer.backend.api.application.domain.Application;
 import com.techeer.backend.api.job.domain.JobPosting;
 import com.techeer.backend.api.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface ApplicationJpaRepository extends JpaRepository<Application, Long> {

--- a/backend/src/main/java/com/techeer/backend/api/application/adapter/out/persistence/ApplicationPersistenceAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/application/adapter/out/persistence/ApplicationPersistenceAdapter.java
@@ -5,10 +5,9 @@ import com.techeer.backend.api.application.application.port.out.SaveApplicationP
 import com.techeer.backend.api.application.domain.Application;
 import com.techeer.backend.api.job.domain.JobPosting;
 import com.techeer.backend.api.user.domain.User;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/techeer/backend/api/application/dto/response/ApplicationInfoResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/application/dto/response/ApplicationInfoResponse.java
@@ -5,5 +5,5 @@ import lombok.Builder;
 
 @Builder
 public record ApplicationInfoResponse(Long id, Long jobPostingId, String jobPostingTitle, String companyName,
-		String status, LocalDateTime appliedAt) {
+									  String status, LocalDateTime appliedAt) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/bookmark/adapter/in/web/BookmarkController.java
+++ b/backend/src/main/java/com/techeer/backend/api/bookmark/adapter/in/web/BookmarkController.java
@@ -24,7 +24,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Bookmark", description = "북마크 API")
@@ -62,7 +61,7 @@ public class BookmarkController {
 	@Operation(summary = "북마크 전체 조회", description = "현재 로그인한 사용자의 북마크 목록을 조회합니다. (Slice 페이지네이션)")
 	@GetMapping
 	public ResponseEntity<ApiResponse<Slice<BookmarkInfoResponse>>> getAllBookmarks(
-			@PageableDefault(size = 10) Pageable pageable) {
+		@PageableDefault(size = 10) Pageable pageable) {
 		Long userId = userService.getLoginUser().getId();
 		Slice<BookmarkInfoResponse> response = getAllBookmarksUseCase.getAllBookmarks(userId, pageable);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.BOOKMARK_GET_SUCCESS, response));

--- a/backend/src/main/java/com/techeer/backend/api/bookmark/adapter/out/persistence/BookmarkJpaRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/bookmark/adapter/out/persistence/BookmarkJpaRepository.java
@@ -3,14 +3,13 @@ package com.techeer.backend.api.bookmark.adapter.out.persistence;
 import com.techeer.backend.api.bookmark.domain.Bookmark;
 import com.techeer.backend.api.job.domain.JobPosting;
 import com.techeer.backend.api.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface BookmarkJpaRepository extends JpaRepository<Bookmark, Long> {

--- a/backend/src/main/java/com/techeer/backend/api/bookmark/adapter/out/persistence/BookmarkPersistenceAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/bookmark/adapter/out/persistence/BookmarkPersistenceAdapter.java
@@ -5,12 +5,11 @@ import com.techeer.backend.api.bookmark.application.port.out.SaveBookmarkPort;
 import com.techeer.backend.api.bookmark.domain.Bookmark;
 import com.techeer.backend.api.job.domain.JobPosting;
 import com.techeer.backend.api.user.domain.User;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/techeer/backend/api/bookmark/domain/Bookmark.java
+++ b/backend/src/main/java/com/techeer/backend/api/bookmark/domain/Bookmark.java
@@ -21,8 +21,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "bookmarks",
-		uniqueConstraints = {
-				@UniqueConstraint(name = "uk_user_jobposting", columnNames = { "user_id", "jobposting_id" }) })
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_user_jobposting", columnNames = {"user_id", "jobposting_id"})})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Bookmark extends BaseEntity {
 

--- a/backend/src/main/java/com/techeer/backend/api/career/adapter/in/web/UserCareerController.java
+++ b/backend/src/main/java/com/techeer/backend/api/career/adapter/in/web/UserCareerController.java
@@ -23,7 +23,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "UserCareer", description = "경력 API")
@@ -61,7 +60,7 @@ public class UserCareerController {
 	@Operation(summary = "경력 수정", description = "경력 정보를 수정합니다. 본인만 가능합니다.")
 	@PutMapping("/{careerId}")
 	public ResponseEntity<ApiResponse<Void>> updateUserCareer(@PathVariable Long careerId,
-			@Valid @RequestBody UserCareerUpdateRequest request) {
+															  @Valid @RequestBody UserCareerUpdateRequest request) {
 		Long userId = userService.getLoginUser().getId();
 		updateUserCareerUseCase.updateUserCareer(careerId, request, userId);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.USER_CAREER_UPDATE_SUCCESS));

--- a/backend/src/main/java/com/techeer/backend/api/career/adapter/out/persistence/UserCareerJpaRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/career/adapter/out/persistence/UserCareerJpaRepository.java
@@ -1,12 +1,11 @@
 package com.techeer.backend.api.career.adapter.out.persistence;
 
 import com.techeer.backend.api.career.domain.UserCareer;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface UserCareerJpaRepository extends JpaRepository<UserCareer, Long> {

--- a/backend/src/main/java/com/techeer/backend/api/career/adapter/out/persistence/UserCareerPersistenceAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/career/adapter/out/persistence/UserCareerPersistenceAdapter.java
@@ -3,10 +3,9 @@ package com.techeer.backend.api.career.adapter.out.persistence;
 import com.techeer.backend.api.career.application.port.out.LoadUserCareerPort;
 import com.techeer.backend.api.career.application.port.out.SaveUserCareerPort;
 import com.techeer.backend.api.career.domain.UserCareer;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/techeer/backend/api/career/application/service/UpdateUserCareerService.java
+++ b/backend/src/main/java/com/techeer/backend/api/career/application/service/UpdateUserCareerService.java
@@ -27,7 +27,7 @@ public class UpdateUserCareerService implements UpdateUserCareerUseCase {
 		}
 
 		userCareer.updateCareer(request.companyName(), request.jobTitle(), request.isCurrent(), request.startDate(),
-				request.endDate());
+			request.endDate());
 	}
 
 }

--- a/backend/src/main/java/com/techeer/backend/api/career/domain/UserCareer.java
+++ b/backend/src/main/java/com/techeer/backend/api/career/domain/UserCareer.java
@@ -64,7 +64,7 @@ public class UserCareer extends BaseEntity {
 
 	@Builder
 	public UserCareer(User user, UserFile file, Company company, String companyName, String jobTitle, Boolean isCurrent,
-			LocalDate startDate, LocalDate endDate) {
+					  LocalDate startDate, LocalDate endDate) {
 		this.user = user;
 		this.file = file;
 		this.company = company;
@@ -76,7 +76,7 @@ public class UserCareer extends BaseEntity {
 	}
 
 	public void updateCareer(String companyName, String jobTitle, Boolean isCurrent, LocalDate startDate,
-			LocalDate endDate) {
+							 LocalDate endDate) {
 		if (companyName != null) {
 			this.companyName = companyName;
 		}

--- a/backend/src/main/java/com/techeer/backend/api/career/dto/request/UserCareerCreateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/career/dto/request/UserCareerCreateRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
 public record UserCareerCreateRequest(
-		@NotNull(message = "회사명은 필수입니다") @Size(max = 100, message = "회사명은 100자를 초과할 수 없습니다") String companyName,
+	@NotNull(message = "회사명은 필수입니다") @Size(max = 100, message = "회사명은 100자를 초과할 수 없습니다") String companyName,
 
-		String jobTitle, Boolean isCurrent, LocalDate startDate, LocalDate endDate) {
+	String jobTitle, Boolean isCurrent, LocalDate startDate, LocalDate endDate) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/career/dto/request/UserCareerUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/career/dto/request/UserCareerUpdateRequest.java
@@ -1,10 +1,9 @@
 package com.techeer.backend.api.career.dto.request;
 
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
 public record UserCareerUpdateRequest(@Size(max = 100, message = "회사명은 100자를 초과할 수 없습니다") String companyName,
 
-		String jobTitle, Boolean isCurrent, LocalDate startDate, LocalDate endDate) {
+									  String jobTitle, Boolean isCurrent, LocalDate startDate, LocalDate endDate) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/career/dto/response/UserCareerInfoResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/career/dto/response/UserCareerInfoResponse.java
@@ -5,5 +5,5 @@ import lombok.Builder;
 
 @Builder
 public record UserCareerInfoResponse(Long id, Long userId, String companyName, String jobTitle, Boolean isCurrent,
-		LocalDate startDate, LocalDate endDate) {
+									 LocalDate startDate, LocalDate endDate) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/company/adapter/in/web/CompanyController.java
+++ b/backend/src/main/java/com/techeer/backend/api/company/adapter/in/web/CompanyController.java
@@ -23,7 +23,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Company", description = "기업 API")
@@ -61,7 +60,7 @@ public class CompanyController {
 	@Operation(summary = "기업 정보 수정", description = "기업 정보를 수정합니다. 기업 관리자 권한이 필요합니다.")
 	@PutMapping("/{companyId}")
 	public ResponseEntity<ApiResponse<Void>> updateCompany(@PathVariable Long companyId,
-			@Valid @RequestBody CompanyUpdateRequest request) {
+														   @Valid @RequestBody CompanyUpdateRequest request) {
 		Long userId = userService.getLoginUser().getId();
 		updateCompanyUseCase.updateCompany(companyId, request, userId);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.COMPANY_UPDATE_SUCCESS));

--- a/backend/src/main/java/com/techeer/backend/api/company/adapter/in/web/CompanyLikeController.java
+++ b/backend/src/main/java/com/techeer/backend/api/company/adapter/in/web/CompanyLikeController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "CompanyLike", description = "기업 좋아요 API")

--- a/backend/src/main/java/com/techeer/backend/api/company/adapter/out/persistence/CompanyLikePersistenceAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/company/adapter/out/persistence/CompanyLikePersistenceAdapter.java
@@ -5,10 +5,9 @@ import com.techeer.backend.api.company.application.port.out.SaveCompanyLikePort;
 import com.techeer.backend.api.company.domain.Company;
 import com.techeer.backend.api.company.domain.CompanyLike;
 import com.techeer.backend.api.user.domain.User;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/techeer/backend/api/company/application/service/RegisterCompanyService.java
+++ b/backend/src/main/java/com/techeer/backend/api/company/application/service/RegisterCompanyService.java
@@ -62,7 +62,7 @@ public class RegisterCompanyService implements RegisterCompanyUseCase {
 		saveCompanyMemberPort.saveCompanyMember(adminMember);
 
 		log.info("Company registered successfully. companyId={}, companyName={}, adminUserId={}", savedCompany.getId(),
-				savedCompany.getName(), userId);
+			savedCompany.getName(), userId);
 
 		return savedCompany.getId();
 	}

--- a/backend/src/main/java/com/techeer/backend/api/company/domain/CompanyLike.java
+++ b/backend/src/main/java/com/techeer/backend/api/company/domain/CompanyLike.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "company_likes",
-		uniqueConstraints = { @UniqueConstraint(name = "uk_user_company", columnNames = { "user_id", "company_id" }) })
+	uniqueConstraints = {@UniqueConstraint(name = "uk_user_company", columnNames = {"user_id", "company_id"})})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CompanyLike extends BaseEntity {
 

--- a/backend/src/main/java/com/techeer/backend/api/company/dto/request/CompanyLikeCreateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/company/dto/request/CompanyLikeCreateRequest.java
@@ -4,5 +4,5 @@ import jakarta.validation.constraints.NotNull;
 
 public record CompanyLikeCreateRequest(@NotNull(message = "기업 ID는 필수입니다") Long companyId,
 
-		@NotNull(message = "사용자 ID는 필수입니다") Long userId) {
+									   @NotNull(message = "사용자 ID는 필수입니다") Long userId) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/company/dto/request/CompanyRegisterRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/company/dto/request/CompanyRegisterRequest.java
@@ -2,17 +2,16 @@ package com.techeer.backend.api.company.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record CompanyRegisterRequest(
-		@NotBlank(message = "기업명은 필수입니다") @Size(max = 100, message = "기업명은 100자를 초과할 수 없습니다") String name,
+	@NotBlank(message = "기업명은 필수입니다") @Size(max = 100, message = "기업명은 100자를 초과할 수 없습니다") String name,
 
-		@Email(message = "올바른 이메일 형식이 아닙니다") @Size(max = 255, message = "이메일은 255자를 초과할 수 없습니다") String companyEmail,
+	@Email(message = "올바른 이메일 형식이 아닙니다") @Size(max = 255, message = "이메일은 255자를 초과할 수 없습니다") String companyEmail,
 
-		@Size(max = 100, message = "산업 분야는 100자를 초과할 수 없습니다") String industryDomain,
+	@Size(max = 100, message = "산업 분야는 100자를 초과할 수 없습니다") String industryDomain,
 
-		@Size(max = 2083, message = "웹사이트 URL은 2083자를 초과할 수 없습니다") String websiteUrl,
+	@Size(max = 2083, message = "웹사이트 URL은 2083자를 초과할 수 없습니다") String websiteUrl,
 
-		@Size(max = 200, message = "위치는 200자를 초과할 수 없습니다") String location) {
+	@Size(max = 200, message = "위치는 200자를 초과할 수 없습니다") String location) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/company/dto/request/CompanyUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/company/dto/request/CompanyUpdateRequest.java
@@ -1,15 +1,14 @@
 package com.techeer.backend.api.company.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record CompanyUpdateRequest(
-		@NotBlank(message = "기업명은 필수입니다") @Size(max = 100, message = "기업명은 100자를 초과할 수 없습니다") String name,
+	@NotBlank(message = "기업명은 필수입니다") @Size(max = 100, message = "기업명은 100자를 초과할 수 없습니다") String name,
 
-		@Size(max = 100, message = "산업 분야는 100자를 초과할 수 없습니다") String industryDomain,
+	@Size(max = 100, message = "산업 분야는 100자를 초과할 수 없습니다") String industryDomain,
 
-		@Size(max = 2083, message = "웹사이트 URL은 2083자를 초과할 수 없습니다") String websiteUrl,
+	@Size(max = 2083, message = "웹사이트 URL은 2083자를 초과할 수 없습니다") String websiteUrl,
 
-		@Size(max = 200, message = "위치는 200자를 초과할 수 없습니다") String location) {
+	@Size(max = 200, message = "위치는 200자를 초과할 수 없습니다") String location) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/document/adapter/in/web/EducationController.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/adapter/in/web/EducationController.java
@@ -53,10 +53,10 @@ public class EducationController {
 	private final UserService userService;
 
 	@Operation(summary = "학력 등록", description = "새로운 학력을 등록합니다. 증명 파일과 함께 업로드하세요.")
-	@PostMapping(consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
+	@PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<ApiResponse<Long>> createEducation(@Parameter(content = @Content(
-			mediaType = MediaType.APPLICATION_JSON_VALUE)) @Valid @RequestPart("request") EducationCreateRequest request,
-			@RequestPart("file") MultipartFile file) {
+																 mediaType = MediaType.APPLICATION_JSON_VALUE)) @Valid @RequestPart("request") EducationCreateRequest request,
+															 @RequestPart("file") MultipartFile file) {
 		Long userId = userService.getLoginUser().getId();
 		Long educationId = createEducationUseCase.createEducation(request, file, userId);
 		return ResponseEntity.status(HttpStatus.CREATED)
@@ -73,7 +73,7 @@ public class EducationController {
 	@Operation(summary = "학력 전체 조회", description = "현재 로그인한 사용자의 학력 목록을 조회합니다. (Slice 페이지네이션)")
 	@GetMapping
 	public ResponseEntity<ApiResponse<Slice<EducationInfoResponse>>> getAllEducations(
-			@PageableDefault(size = 10) Pageable pageable) {
+		@PageableDefault(size = 10) Pageable pageable) {
 		Long userId = userService.getLoginUser().getId();
 		Slice<EducationInfoResponse> response = getAllEducationsUseCase.getAllEducations(userId, pageable);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.EDUCATION_GET_SUCCESS, response));
@@ -82,7 +82,7 @@ public class EducationController {
 	@Operation(summary = "학력 수정", description = "학력 정보를 수정합니다.")
 	@PutMapping("/{educationId}")
 	public ResponseEntity<ApiResponse<Void>> updateEducation(@PathVariable Long educationId,
-			@Valid @RequestBody EducationUpdateRequest request) {
+															 @Valid @RequestBody EducationUpdateRequest request) {
 		Long userId = userService.getLoginUser().getId();
 		updateEducationUseCase.updateEducation(educationId, request, userId);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.EDUCATION_UPDATE_SUCCESS));

--- a/backend/src/main/java/com/techeer/backend/api/document/adapter/in/web/PortfolioController.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/adapter/in/web/PortfolioController.java
@@ -53,10 +53,10 @@ public class PortfolioController {
 	private final UserService userService;
 
 	@Operation(summary = "포트폴리오 등록", description = "새로운 포트폴리오를 등록합니다. 파일과 함께 업로드하세요.")
-	@PostMapping(consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
+	@PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<ApiResponse<Long>> createPortfolio(@Parameter(content = @Content(
-			mediaType = MediaType.APPLICATION_JSON_VALUE)) @Valid @RequestPart("request") PortfolioCreateRequest request,
-			@RequestPart("file") MultipartFile file) {
+																 mediaType = MediaType.APPLICATION_JSON_VALUE)) @Valid @RequestPart("request") PortfolioCreateRequest request,
+															 @RequestPart("file") MultipartFile file) {
 		Long userId = userService.getLoginUser().getId();
 		Long portfolioId = createPortfolioUseCase.createPortfolio(request, file, userId);
 		return ResponseEntity.status(HttpStatus.CREATED)
@@ -73,7 +73,7 @@ public class PortfolioController {
 	@Operation(summary = "포트폴리오 전체 조회", description = "현재 로그인한 사용자의 포트폴리오 목록을 조회합니다. (Slice 페이지네이션)")
 	@GetMapping
 	public ResponseEntity<ApiResponse<Slice<PortfolioInfoResponse>>> getAllPortfolios(
-			@PageableDefault(size = 10) Pageable pageable) {
+		@PageableDefault(size = 10) Pageable pageable) {
 		Long userId = userService.getLoginUser().getId();
 		Slice<PortfolioInfoResponse> response = getAllPortfoliosUseCase.getAllPortfolios(userId, pageable);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.PORTFOLIO_GET_SUCCESS, response));
@@ -82,7 +82,7 @@ public class PortfolioController {
 	@Operation(summary = "포트폴리오 수정", description = "포트폴리오 정보를 수정합니다.")
 	@PutMapping("/{portfolioId}")
 	public ResponseEntity<ApiResponse<Void>> updatePortfolio(@PathVariable Long portfolioId,
-			@Valid @RequestBody PortfolioUpdateRequest request) {
+															 @Valid @RequestBody PortfolioUpdateRequest request) {
 		Long userId = userService.getLoginUser().getId();
 		updatePortfolioUseCase.updatePortfolio(portfolioId, request, userId);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.PORTFOLIO_UPDATE_SUCCESS));

--- a/backend/src/main/java/com/techeer/backend/api/document/adapter/in/web/ResumeController.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/adapter/in/web/ResumeController.java
@@ -30,7 +30,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -54,10 +53,10 @@ public class ResumeController {
 	private final UserService userService;
 
 	@Operation(summary = "이력서 등록", description = "새로운 이력서를 등록합니다. 파일과 함께 업로드하세요.")
-	@PostMapping(consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
+	@PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<ApiResponse<Long>> createResume(@Parameter(content = @Content(
-			mediaType = MediaType.APPLICATION_JSON_VALUE)) @Valid @RequestPart("request") ResumeCreateRequest request,
-			@RequestPart("file") MultipartFile file) {
+															  mediaType = MediaType.APPLICATION_JSON_VALUE)) @Valid @RequestPart("request") ResumeCreateRequest request,
+														  @RequestPart("file") MultipartFile file) {
 		Long userId = userService.getLoginUser().getId();
 		Long resumeId = createResumeUseCase.createResume(request, file, userId);
 		return ResponseEntity.status(HttpStatus.CREATED)
@@ -74,7 +73,7 @@ public class ResumeController {
 	@Operation(summary = "이력서 전체 조회", description = "현재 로그인한 사용자의 이력서 목록을 조회합니다. (Slice 페이지네이션)")
 	@GetMapping
 	public ResponseEntity<ApiResponse<Slice<ResumeInfoResponse>>> getAllResumes(
-			@PageableDefault(size = 10) Pageable pageable) {
+		@PageableDefault(size = 10) Pageable pageable) {
 		Long userId = userService.getLoginUser().getId();
 		Slice<ResumeInfoResponse> response = getAllResumesUseCase.getAllResumes(userId, pageable);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.RESUME_GET_SUCCESS, response));
@@ -83,7 +82,7 @@ public class ResumeController {
 	@Operation(summary = "이력서 수정", description = "이력서를 수정합니다. 본인만 가능합니다.")
 	@PutMapping("/{resumeId}")
 	public ResponseEntity<ApiResponse<Void>> updateResume(@PathVariable Long resumeId,
-			@Valid @RequestBody ResumeUpdateRequest request) {
+														  @Valid @RequestBody ResumeUpdateRequest request) {
 		Long userId = userService.getLoginUser().getId();
 		updateResumeUseCase.updateResume(resumeId, request, userId);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.RESUME_UPDATE_SUCCESS));

--- a/backend/src/main/java/com/techeer/backend/api/document/adapter/out/persistence/EducationJpaRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/adapter/out/persistence/EducationJpaRepository.java
@@ -2,14 +2,13 @@ package com.techeer.backend.api.document.adapter.out.persistence;
 
 import com.techeer.backend.api.document.domain.Education;
 import com.techeer.backend.api.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface EducationJpaRepository extends JpaRepository<Education, Long> {
@@ -24,7 +23,7 @@ public interface EducationJpaRepository extends JpaRepository<Education, Long> {
 	 * 특정 사용자의 삭제되지 않은 학력 전체 조회 (Slice 페이지네이션) UserFile을 통해 User를 찾아서 조회
 	 */
 	@Query("SELECT e FROM Education e " + "WHERE e.file.user = :user AND e.deletedAt IS NULL "
-			+ "ORDER BY e.createdAt DESC")
+		+ "ORDER BY e.createdAt DESC")
 	Slice<Education> findAllByUserAndNotDeleted(@Param("user") User user, Pageable pageable);
 
 }

--- a/backend/src/main/java/com/techeer/backend/api/document/adapter/out/persistence/EducationPersistenceAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/adapter/out/persistence/EducationPersistenceAdapter.java
@@ -4,12 +4,11 @@ import com.techeer.backend.api.document.application.port.out.LoadEducationPort;
 import com.techeer.backend.api.document.application.port.out.SaveEducationPort;
 import com.techeer.backend.api.document.domain.Education;
 import com.techeer.backend.api.user.domain.User;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/techeer/backend/api/document/adapter/out/persistence/ResumeJpaRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/adapter/out/persistence/ResumeJpaRepository.java
@@ -2,14 +2,13 @@ package com.techeer.backend.api.document.adapter.out.persistence;
 
 import com.techeer.backend.api.document.domain.Resume;
 import com.techeer.backend.api.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface ResumeJpaRepository extends JpaRepository<Resume, Long> {

--- a/backend/src/main/java/com/techeer/backend/api/document/adapter/out/persistence/ResumePersistenceAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/adapter/out/persistence/ResumePersistenceAdapter.java
@@ -4,12 +4,11 @@ import com.techeer.backend.api.document.application.port.out.LoadResumePort;
 import com.techeer.backend.api.document.application.port.out.SaveResumePort;
 import com.techeer.backend.api.document.domain.Resume;
 import com.techeer.backend.api.user.domain.User;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/techeer/backend/api/document/application/port/out/LoadEducationPort.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/application/port/out/LoadEducationPort.java
@@ -2,10 +2,9 @@ package com.techeer.backend.api.document.application.port.out;
 
 import com.techeer.backend.api.document.domain.Education;
 import com.techeer.backend.api.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-
-import java.util.Optional;
 
 public interface LoadEducationPort {
 

--- a/backend/src/main/java/com/techeer/backend/api/document/application/service/CreateEducationService.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/application/service/CreateEducationService.java
@@ -60,16 +60,21 @@ public class CreateEducationService implements CreateEducationUseCase {
 	}
 
 	private FileType mapToFileType(String contentType) {
-		if (contentType == null)
+		if (contentType == null) {
 			return FileType.OTHER;
-		if (contentType.startsWith("image/"))
+		}
+		if (contentType.startsWith("image/")) {
 			return FileType.IMAGE;
-		if (contentType.equals("application/pdf"))
+		}
+		if (contentType.equals("application/pdf")) {
 			return FileType.PDF;
-		if (contentType.contains("msword") || contentType.contains("wordprocessingml"))
+		}
+		if (contentType.contains("msword") || contentType.contains("wordprocessingml")) {
 			return FileType.WORD;
-		if (contentType.contains("excel") || contentType.contains("spreadsheetml"))
+		}
+		if (contentType.contains("excel") || contentType.contains("spreadsheetml")) {
 			return FileType.EXCEL;
+		}
 		return FileType.OTHER;
 	}
 

--- a/backend/src/main/java/com/techeer/backend/api/document/application/service/CreatePortfolioService.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/application/service/CreatePortfolioService.java
@@ -60,16 +60,21 @@ public class CreatePortfolioService implements CreatePortfolioUseCase {
 	}
 
 	private FileType mapToFileType(String contentType) {
-		if (contentType == null)
+		if (contentType == null) {
 			return FileType.OTHER;
-		if (contentType.startsWith("image/"))
+		}
+		if (contentType.startsWith("image/")) {
 			return FileType.IMAGE;
-		if (contentType.equals("application/pdf"))
+		}
+		if (contentType.equals("application/pdf")) {
 			return FileType.PDF;
-		if (contentType.contains("msword") || contentType.contains("wordprocessingml"))
+		}
+		if (contentType.contains("msword") || contentType.contains("wordprocessingml")) {
 			return FileType.WORD;
-		if (contentType.contains("excel") || contentType.contains("spreadsheetml"))
+		}
+		if (contentType.contains("excel") || contentType.contains("spreadsheetml")) {
 			return FileType.EXCEL;
+		}
 		return FileType.OTHER;
 	}
 

--- a/backend/src/main/java/com/techeer/backend/api/document/application/service/CreateResumeService.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/application/service/CreateResumeService.java
@@ -59,16 +59,21 @@ public class CreateResumeService implements CreateResumeUseCase {
 	}
 
 	private FileType mapToFileType(String contentType) {
-		if (contentType == null)
+		if (contentType == null) {
 			return FileType.OTHER;
-		if (contentType.startsWith("image/"))
+		}
+		if (contentType.startsWith("image/")) {
 			return FileType.IMAGE;
-		if (contentType.equals("application/pdf"))
+		}
+		if (contentType.equals("application/pdf")) {
 			return FileType.PDF;
-		if (contentType.contains("msword") || contentType.contains("wordprocessingml"))
+		}
+		if (contentType.contains("msword") || contentType.contains("wordprocessingml")) {
 			return FileType.WORD;
-		if (contentType.contains("excel") || contentType.contains("spreadsheetml"))
+		}
+		if (contentType.contains("excel") || contentType.contains("spreadsheetml")) {
 			return FileType.EXCEL;
+		}
 		return FileType.OTHER;
 	}
 

--- a/backend/src/main/java/com/techeer/backend/api/document/application/service/UpdateEducationService.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/application/service/UpdateEducationService.java
@@ -31,8 +31,7 @@ public class UpdateEducationService implements UpdateEducationUseCase {
 		if (request.isDefault() != null) {
 			if (request.isDefault()) {
 				education.setAsDefault();
-			}
-			else {
+			} else {
 				education.unsetAsDefault();
 			}
 		}

--- a/backend/src/main/java/com/techeer/backend/api/document/application/service/UpdatePortfolioService.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/application/service/UpdatePortfolioService.java
@@ -31,8 +31,7 @@ public class UpdatePortfolioService implements UpdatePortfolioUseCase {
 		if (request.isDefault() != null) {
 			if (request.isDefault()) {
 				portfolio.setAsDefault();
-			}
-			else {
+			} else {
 				portfolio.unsetAsDefault();
 			}
 		}

--- a/backend/src/main/java/com/techeer/backend/api/document/application/service/UpdateResumeService.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/application/service/UpdateResumeService.java
@@ -31,8 +31,7 @@ public class UpdateResumeService implements UpdateResumeUseCase {
 		if (request.isDefault() != null) {
 			if (request.isDefault()) {
 				resume.setAsDefault();
-			}
-			else {
+			} else {
 				resume.unsetAsDefault();
 			}
 		}

--- a/backend/src/main/java/com/techeer/backend/api/document/dto/request/EducationCreateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/dto/request/EducationCreateRequest.java
@@ -4,5 +4,5 @@ import jakarta.validation.constraints.Size;
 
 public record EducationCreateRequest(@Size(max = 255, message = "제목은 255자를 초과할 수 없습니다") String title,
 
-		Boolean isDefault) {
+									 Boolean isDefault) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/document/dto/request/EducationUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/dto/request/EducationUpdateRequest.java
@@ -4,5 +4,5 @@ import jakarta.validation.constraints.Size;
 
 public record EducationUpdateRequest(@Size(max = 255, message = "제목은 255자를 초과할 수 없습니다") String title,
 
-		Boolean isDefault) {
+									 Boolean isDefault) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/document/dto/request/PortfolioCreateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/dto/request/PortfolioCreateRequest.java
@@ -4,5 +4,5 @@ import jakarta.validation.constraints.Size;
 
 public record PortfolioCreateRequest(@Size(max = 255, message = "제목은 255자를 초과할 수 없습니다") String title,
 
-		Boolean isDefault) {
+									 Boolean isDefault) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/document/dto/request/PortfolioUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/dto/request/PortfolioUpdateRequest.java
@@ -4,5 +4,5 @@ import jakarta.validation.constraints.Size;
 
 public record PortfolioUpdateRequest(@Size(max = 255, message = "제목은 255자를 초과할 수 없습니다") String title,
 
-		Boolean isDefault) {
+									 Boolean isDefault) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/document/dto/request/ResumeCreateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/dto/request/ResumeCreateRequest.java
@@ -4,5 +4,5 @@ import jakarta.validation.constraints.Size;
 
 public record ResumeCreateRequest(@Size(max = 255, message = "제목은 255자를 초과할 수 없습니다") String title,
 
-		Boolean isDefault) {
+								  Boolean isDefault) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/document/dto/request/ResumeUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/document/dto/request/ResumeUpdateRequest.java
@@ -4,5 +4,5 @@ import jakarta.validation.constraints.Size;
 
 public record ResumeUpdateRequest(@Size(max = 255, message = "제목은 255자를 초과할 수 없습니다") String title,
 
-		Boolean isDefault) {
+								  Boolean isDefault) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/file/adapter/out/persistence/UserFilePersistenceAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/file/adapter/out/persistence/UserFilePersistenceAdapter.java
@@ -3,10 +3,9 @@ package com.techeer.backend.api.file.adapter.out.persistence;
 import com.techeer.backend.api.file.application.port.out.LoadUserFilePort;
 import com.techeer.backend.api.file.application.port.out.SaveUserFilePort;
 import com.techeer.backend.api.file.domain.UserFile;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/techeer/backend/api/file/controller/FileTestController.java
+++ b/backend/src/main/java/com/techeer/backend/api/file/controller/FileTestController.java
@@ -46,12 +46,12 @@ public class FileTestController {
 	@Operation(summary = "문서 파일 업로드 테스트", description = "현재 로그인한 사용자의 문서 파일(이력서, 포트폴리오 등)을 업로드합니다.")
 	@PostMapping("/document")
 	public ResponseEntity<ApiResponse<String>> uploadDocument(@RequestParam("file") MultipartFile file,
-			@RequestParam(value = "type", defaultValue = "resume") String documentType) {
+															  @RequestParam(value = "type", defaultValue = "resume") String documentType) {
 		User user = userService.getLoginUser();
 		FileMetadata fileMetadata = gcsUploader.uploadDocument(file, user.getId(), documentType);
 
 		log.info("문서 파일 업로드 성공: userId={}, documentType={}, fileUrl={}", user.getId(), documentType,
-				fileMetadata.getFileUrl());
+			fileMetadata.getFileUrl());
 
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.FILE_UPLOAD_SUCCESS, fileMetadata.getFileUrl()));
 	}
@@ -59,12 +59,12 @@ public class FileTestController {
 	@Operation(summary = "증명 파일 업로드 테스트", description = "현재 로그인한 사용자의 증명 파일(학력, 자격증 등)을 업로드합니다.")
 	@PostMapping("/verification")
 	public ResponseEntity<ApiResponse<String>> uploadVerification(@RequestParam("file") MultipartFile file,
-			@RequestParam(value = "type", defaultValue = "education") String verificationType) {
+																  @RequestParam(value = "type", defaultValue = "education") String verificationType) {
 		User user = userService.getLoginUser();
 		FileMetadata fileMetadata = gcsUploader.uploadVerification(file, user.getId(), verificationType);
 
 		log.info("증명 파일 업로드 성공: userId={}, verificationType={}, fileUrl={}", user.getId(), verificationType,
-				fileMetadata.getFileUrl());
+			fileMetadata.getFileUrl());
 
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.FILE_UPLOAD_SUCCESS, fileMetadata.getFileUrl()));
 	}

--- a/backend/src/main/java/com/techeer/backend/api/file/domain/UserFile.java
+++ b/backend/src/main/java/com/techeer/backend/api/file/domain/UserFile.java
@@ -27,44 +27,37 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserFile {
 
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private final LocalDateTime createdAt = LocalDateTime.now();
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "file_id")
 	private Long id;
-
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
-
 	@NotNull
 	@Enumerated(EnumType.STRING)
 	@Column(name = "category", nullable = false, length = 50)
 	private FileCategory category;
-
 	@NotNull
 	@Size(max = 36)
 	@Column(name = "uuid", nullable = false, length = 36, unique = true)
 	private String uuid;
-
 	@NotNull
 	@Size(max = 2083)
 	@Column(name = "file_url", nullable = false, length = 2083)
 	private String fileUrl;
-
 	@Enumerated(EnumType.STRING)
 	@Column(name = "file_type", length = 50)
 	private FileType fileType;
-
 	@Size(max = 255)
 	@Column(name = "original_name", length = 255)
 	private String originalName;
 
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt = LocalDateTime.now();
-
 	@Builder
 	public UserFile(User user, FileCategory category, String uuid, String fileUrl, FileType fileType,
-			String originalName) {
+					String originalName) {
 		this.user = user;
 		this.category = category;
 		this.uuid = uuid;

--- a/backend/src/main/java/com/techeer/backend/api/job/adapter/in/web/JobPostingController.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/adapter/in/web/JobPostingController.java
@@ -23,7 +23,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "JobPosting", description = "채용공고 API")
@@ -61,7 +60,7 @@ public class JobPostingController {
 	@Operation(summary = "채용공고 수정", description = "채용공고를 수정합니다. 기업 관리자 권한이 필요합니다.")
 	@PutMapping("/{jobPostingId}")
 	public ResponseEntity<ApiResponse<Void>> updateJobPosting(@PathVariable Long jobPostingId,
-			@Valid @RequestBody JobPostingUpdateRequest request) {
+															  @Valid @RequestBody JobPostingUpdateRequest request) {
 		Long userId = userService.getLoginUser().getId();
 		updateJobPostingUseCase.updateJobPosting(jobPostingId, request, userId);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.JOB_POSTING_UPDATE_SUCCESS));

--- a/backend/src/main/java/com/techeer/backend/api/job/adapter/out/persistence/JobPostingJpaRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/adapter/out/persistence/JobPostingJpaRepository.java
@@ -1,12 +1,11 @@
 package com.techeer.backend.api.job.adapter.out.persistence;
 
 import com.techeer.backend.api.job.domain.JobPosting;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface JobPostingJpaRepository extends JpaRepository<JobPosting, Long> {

--- a/backend/src/main/java/com/techeer/backend/api/job/domain/JobPosting.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/domain/JobPosting.java
@@ -62,7 +62,7 @@ public class JobPosting extends BaseEntity {
 
 	@Builder
 	public JobPosting(Company company, String title, String contents, Integer expYears, SourceType sourceType,
-			String originUrl, JobPostingStatus status) {
+					  String originUrl, JobPostingStatus status) {
 		this.company = company;
 		this.title = title;
 		this.contents = contents;

--- a/backend/src/main/java/com/techeer/backend/api/job/domain/JobSkill.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/domain/JobSkill.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "job_skills",
-		uniqueConstraints = { @UniqueConstraint(name = "uk_job_skill", columnNames = { "jobposting_id", "skill_id" }) })
+	uniqueConstraints = {@UniqueConstraint(name = "uk_job_skill", columnNames = {"jobposting_id", "skill_id"})})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class JobSkill {
 

--- a/backend/src/main/java/com/techeer/backend/api/job/dto/request/JobPostingCreateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/dto/request/JobPostingCreateRequest.java
@@ -5,9 +5,9 @@ import jakarta.validation.constraints.Size;
 
 public record JobPostingCreateRequest(@NotNull(message = "회사 ID는 필수입니다") Long companyId,
 
-		@NotNull(message = "제목은 필수입니다") @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다") String title,
+									  @NotNull(message = "제목은 필수입니다") @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다") String title,
 
-		String contents,
+									  String contents,
 
-		Integer expYears) {
+									  Integer expYears) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/job/dto/request/JobPostingUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/dto/request/JobPostingUpdateRequest.java
@@ -1,11 +1,10 @@
 package com.techeer.backend.api.job.dto.request;
 
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record JobPostingUpdateRequest(@Size(max = 200, message = "제목은 200자를 초과할 수 없습니다") String title,
 
-		String contents,
+									  String contents,
 
-		Integer expYears) {
+									  Integer expYears) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/job/dto/response/JobPostingInfoResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/dto/response/JobPostingInfoResponse.java
@@ -4,5 +4,5 @@ import lombok.Builder;
 
 @Builder
 public record JobPostingInfoResponse(Long id, Long companyId, String companyName, String title, String contents,
-		Integer expYears, String status) {
+									 Integer expYears, String status) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/skill/adapter/in/web/SkillController.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/adapter/in/web/SkillController.java
@@ -1,0 +1,72 @@
+package com.techeer.backend.api.skill.adapter.in.web;
+
+import com.techeer.backend.api.skill.application.port.in.CreateSkillUseCase;
+import com.techeer.backend.api.skill.application.port.in.DeleteSkillUseCase;
+import com.techeer.backend.api.skill.application.port.in.GetSkillUseCase;
+import com.techeer.backend.api.skill.application.port.in.UpdateSkillUseCase;
+import com.techeer.backend.api.skill.dto.request.SkillCreateRequest;
+import com.techeer.backend.api.skill.dto.request.SkillUpdateRequest;
+import com.techeer.backend.api.skill.dto.response.SkillInfoResponse;
+import com.techeer.backend.global.dto.ApiResponse;
+import com.techeer.backend.global.success.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Skill", description = "기술 스택 API")
+@RestController
+@RequestMapping("/api/v1/skills")
+@RequiredArgsConstructor
+public class SkillController {
+
+	private final CreateSkillUseCase createSkillUseCase;
+
+	private final GetSkillUseCase getSkillUseCase;
+
+	private final UpdateSkillUseCase updateSkillUseCase;
+
+	private final DeleteSkillUseCase deleteSkillUseCase;
+
+	@Operation(summary = "기술 스택 등록", description = "새로운 기술 스택을 등록합니다.")
+	@PostMapping
+	public ResponseEntity<ApiResponse<Long>> createSkill(@Valid @RequestBody SkillCreateRequest request) {
+		Long skillId = createSkillUseCase.createSkill(request);
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(ApiResponse.success(SuccessCode.SKILL_CREATE_SUCCESS, skillId));
+	}
+
+	@Operation(summary = "기술 스택 단건 조회", description = "기술 스택 ID로 기술 스택 정보를 조회합니다.")
+	@GetMapping("/{skillId}")
+	public ResponseEntity<ApiResponse<SkillInfoResponse>> getSkill(@PathVariable Long skillId) {
+		SkillInfoResponse response = getSkillUseCase.getSkill(skillId);
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.SKILL_GET_SUCCESS, response));
+	}
+
+	@Operation(summary = "기술 스택 수정", description = "기술 스택 정보를 수정합니다.")
+	@PutMapping("/{skillId}")
+	public ResponseEntity<ApiResponse<Void>> updateSkill(@PathVariable Long skillId,
+														 @Valid @RequestBody SkillUpdateRequest request) {
+		updateSkillUseCase.updateSkill(skillId, request);
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.SKILL_UPDATE_SUCCESS));
+	}
+
+	@Operation(summary = "기술 스택 삭제", description = "기술 스택을 삭제합니다. (Soft Delete)")
+	@DeleteMapping("/{skillId}")
+	public ResponseEntity<ApiResponse<Void>> deleteSkill(@PathVariable Long skillId) {
+		deleteSkillUseCase.deleteSkill(skillId);
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.SKILL_DELETE_SUCCESS));
+	}
+
+}
+

--- a/backend/src/main/java/com/techeer/backend/api/skill/adapter/in/web/UserSkillController.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/adapter/in/web/UserSkillController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "UserSkill", description = "스킬 API")

--- a/backend/src/main/java/com/techeer/backend/api/skill/adapter/out/persistence/SkillJpaRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/adapter/out/persistence/SkillJpaRepository.java
@@ -1,10 +1,29 @@
 package com.techeer.backend.api.skill.adapter.out.persistence;
 
 import com.techeer.backend.api.skill.domain.Skill;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SkillJpaRepository extends JpaRepository<Skill, Long> {
+
+	Optional<Skill> findByName(String name);
+
+	Optional<Skill> findByNameIgnoreCase(String name);
+
+	/**
+	 * 삭제되지 않은 기술 스택 조회 Soft Delete 적용: deletedAt IS NULL인 경우만 조회
+	 */
+	@Query("SELECT s FROM Skill s WHERE s.id = :id AND s.deletedAt IS NULL")
+	Optional<Skill> findByIdAndNotDeleted(@Param("id") Long id);
+
+	/**
+	 * 삭제되지 않은 기술 스택을 이름으로 조회 (대소문자 구분 없이) Soft Delete 적용: deletedAt IS NULL인 경우만 조회
+	 */
+	@Query("SELECT s FROM Skill s WHERE LOWER(s.name) = LOWER(:name) AND s.deletedAt IS NULL")
+	Optional<Skill> findByNameIgnoreCaseAndNotDeleted(@Param("name") String name);
 
 }

--- a/backend/src/main/java/com/techeer/backend/api/skill/adapter/out/persistence/SkillPersistenceAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/adapter/out/persistence/SkillPersistenceAdapter.java
@@ -1,6 +1,7 @@
 package com.techeer.backend.api.skill.adapter.out.persistence;
 
 import com.techeer.backend.api.skill.application.port.out.LoadSkillPort;
+import com.techeer.backend.api.skill.application.port.out.SaveSkillPort;
 import com.techeer.backend.api.skill.domain.Skill;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -8,13 +9,38 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class SkillPersistenceAdapter implements LoadSkillPort {
+public class SkillPersistenceAdapter implements LoadSkillPort, SaveSkillPort {
 
 	private final SkillJpaRepository skillJpaRepository;
 
 	@Override
 	public Optional<Skill> findById(Long id) {
 		return skillJpaRepository.findById(id);
+	}
+
+	@Override
+	public Optional<Skill> findByName(String name) {
+		return skillJpaRepository.findByName(name);
+	}
+
+	@Override
+	public Optional<Skill> findByNameIgnoreCase(String name) {
+		return skillJpaRepository.findByNameIgnoreCase(name);
+	}
+
+	@Override
+	public Optional<Skill> findByIdAndNotDeleted(Long id) {
+		return skillJpaRepository.findByIdAndNotDeleted(id);
+	}
+
+	@Override
+	public Optional<Skill> findByNameIgnoreCaseAndNotDeleted(String name) {
+		return skillJpaRepository.findByNameIgnoreCaseAndNotDeleted(name);
+	}
+
+	@Override
+	public Skill saveSkill(Skill skill) {
+		return skillJpaRepository.save(skill);
 	}
 
 }

--- a/backend/src/main/java/com/techeer/backend/api/skill/adapter/out/persistence/UserSkillJpaRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/adapter/out/persistence/UserSkillJpaRepository.java
@@ -3,12 +3,11 @@ package com.techeer.backend.api.skill.adapter.out.persistence;
 import com.techeer.backend.api.skill.domain.Skill;
 import com.techeer.backend.api.skill.domain.UserSkill;
 import com.techeer.backend.api.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface UserSkillJpaRepository extends JpaRepository<UserSkill, Long> {

--- a/backend/src/main/java/com/techeer/backend/api/skill/adapter/out/persistence/UserSkillPersistenceAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/adapter/out/persistence/UserSkillPersistenceAdapter.java
@@ -5,10 +5,9 @@ import com.techeer.backend.api.skill.application.port.out.SaveUserSkillPort;
 import com.techeer.backend.api.skill.domain.Skill;
 import com.techeer.backend.api.skill.domain.UserSkill;
 import com.techeer.backend.api.user.domain.User;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/techeer/backend/api/skill/application/port/in/CreateSkillUseCase.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/application/port/in/CreateSkillUseCase.java
@@ -1,0 +1,10 @@
+package com.techeer.backend.api.skill.application.port.in;
+
+import com.techeer.backend.api.skill.dto.request.SkillCreateRequest;
+
+public interface CreateSkillUseCase {
+
+	Long createSkill(SkillCreateRequest request);
+
+}
+

--- a/backend/src/main/java/com/techeer/backend/api/skill/application/port/in/DeleteSkillUseCase.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/application/port/in/DeleteSkillUseCase.java
@@ -1,0 +1,8 @@
+package com.techeer.backend.api.skill.application.port.in;
+
+public interface DeleteSkillUseCase {
+
+	void deleteSkill(Long skillId);
+
+}
+

--- a/backend/src/main/java/com/techeer/backend/api/skill/application/port/in/GetSkillUseCase.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/application/port/in/GetSkillUseCase.java
@@ -1,0 +1,10 @@
+package com.techeer.backend.api.skill.application.port.in;
+
+import com.techeer.backend.api.skill.dto.response.SkillInfoResponse;
+
+public interface GetSkillUseCase {
+
+	SkillInfoResponse getSkill(Long skillId);
+
+}
+

--- a/backend/src/main/java/com/techeer/backend/api/skill/application/port/in/UpdateSkillUseCase.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/application/port/in/UpdateSkillUseCase.java
@@ -1,0 +1,10 @@
+package com.techeer.backend.api.skill.application.port.in;
+
+import com.techeer.backend.api.skill.dto.request.SkillUpdateRequest;
+
+public interface UpdateSkillUseCase {
+
+	void updateSkill(Long skillId, SkillUpdateRequest request);
+
+}
+

--- a/backend/src/main/java/com/techeer/backend/api/skill/application/port/out/LoadSkillPort.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/application/port/out/LoadSkillPort.java
@@ -7,4 +7,12 @@ public interface LoadSkillPort {
 
 	Optional<Skill> findById(Long id);
 
+	Optional<Skill> findByName(String name);
+
+	Optional<Skill> findByNameIgnoreCase(String name);
+
+	Optional<Skill> findByIdAndNotDeleted(Long id);
+
+	Optional<Skill> findByNameIgnoreCaseAndNotDeleted(String name);
+
 }

--- a/backend/src/main/java/com/techeer/backend/api/skill/application/port/out/SaveSkillPort.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/application/port/out/SaveSkillPort.java
@@ -1,0 +1,10 @@
+package com.techeer.backend.api.skill.application.port.out;
+
+import com.techeer.backend.api.skill.domain.Skill;
+
+public interface SaveSkillPort {
+
+	Skill saveSkill(Skill skill);
+
+}
+

--- a/backend/src/main/java/com/techeer/backend/api/skill/application/service/CreateSkillService.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/application/service/CreateSkillService.java
@@ -1,0 +1,38 @@
+package com.techeer.backend.api.skill.application.service;
+
+import com.techeer.backend.api.skill.application.port.in.CreateSkillUseCase;
+import com.techeer.backend.api.skill.application.port.out.LoadSkillPort;
+import com.techeer.backend.api.skill.application.port.out.SaveSkillPort;
+import com.techeer.backend.api.skill.domain.Skill;
+import com.techeer.backend.api.skill.dto.request.SkillCreateRequest;
+import com.techeer.backend.global.error.ErrorCode;
+import com.techeer.backend.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateSkillService implements CreateSkillUseCase {
+
+	private final LoadSkillPort loadSkillPort;
+
+	private final SaveSkillPort saveSkillPort;
+
+	@Override
+	public Long createSkill(SkillCreateRequest request) {
+		// 스킬명 중복 체크 (대소문자 구분 없이, Soft Delete된 것은 제외)
+		if (loadSkillPort.findByNameIgnoreCaseAndNotDeleted(request.name()).isPresent()) {
+			throw new BusinessException(ErrorCode.SKILL_ALREADY_EXISTS);
+		}
+
+		Skill skill = Skill.builder()
+			.name(request.name())
+			.build();
+
+		return saveSkillPort.saveSkill(skill).getId();
+	}
+
+}
+

--- a/backend/src/main/java/com/techeer/backend/api/skill/application/service/DeleteSkillService.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/application/service/DeleteSkillService.java
@@ -1,0 +1,29 @@
+package com.techeer.backend.api.skill.application.service;
+
+import com.techeer.backend.api.skill.application.port.in.DeleteSkillUseCase;
+import com.techeer.backend.api.skill.application.port.out.LoadSkillPort;
+import com.techeer.backend.api.skill.domain.Skill;
+import com.techeer.backend.global.error.ErrorCode;
+import com.techeer.backend.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteSkillService implements DeleteSkillUseCase {
+
+	private final LoadSkillPort loadSkillPort;
+
+	@Override
+	public void deleteSkill(Long skillId) {
+		Skill skill = loadSkillPort.findByIdAndNotDeleted(skillId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.SKILL_NOT_FOUND));
+
+		// Soft Delete: BaseEntity의 softDelete() 메서드 사용
+		skill.softDelete();
+	}
+
+}
+

--- a/backend/src/main/java/com/techeer/backend/api/skill/application/service/GetSkillService.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/application/service/GetSkillService.java
@@ -1,0 +1,32 @@
+package com.techeer.backend.api.skill.application.service;
+
+import com.techeer.backend.api.skill.application.port.in.GetSkillUseCase;
+import com.techeer.backend.api.skill.application.port.out.LoadSkillPort;
+import com.techeer.backend.api.skill.domain.Skill;
+import com.techeer.backend.api.skill.dto.response.SkillInfoResponse;
+import com.techeer.backend.global.error.ErrorCode;
+import com.techeer.backend.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetSkillService implements GetSkillUseCase {
+
+	private final LoadSkillPort loadSkillPort;
+
+	@Override
+	public SkillInfoResponse getSkill(Long skillId) {
+		Skill skill = loadSkillPort.findByIdAndNotDeleted(skillId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.SKILL_NOT_FOUND));
+
+		return SkillInfoResponse.builder()
+			.id(skill.getId())
+			.name(skill.getName())
+			.build();
+	}
+
+}
+

--- a/backend/src/main/java/com/techeer/backend/api/skill/application/service/UpdateSkillService.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/application/service/UpdateSkillService.java
@@ -1,0 +1,39 @@
+package com.techeer.backend.api.skill.application.service;
+
+import com.techeer.backend.api.skill.application.port.in.UpdateSkillUseCase;
+import com.techeer.backend.api.skill.application.port.out.LoadSkillPort;
+import com.techeer.backend.api.skill.application.port.out.SaveSkillPort;
+import com.techeer.backend.api.skill.domain.Skill;
+import com.techeer.backend.api.skill.dto.request.SkillUpdateRequest;
+import com.techeer.backend.global.error.ErrorCode;
+import com.techeer.backend.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdateSkillService implements UpdateSkillUseCase {
+
+	private final LoadSkillPort loadSkillPort;
+
+	private final SaveSkillPort saveSkillPort;
+
+	@Override
+	public void updateSkill(Long skillId, SkillUpdateRequest request) {
+		Skill skill = loadSkillPort.findById(skillId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.SKILL_NOT_FOUND));
+
+		// 스킬명 변경 시 중복 체크 (대소문자 구분 없이, Soft Delete된 것은 제외)
+		if (request.name() != null && !request.name().equalsIgnoreCase(skill.getName())) {
+			if (loadSkillPort.findByNameIgnoreCaseAndNotDeleted(request.name()).isPresent()) {
+				throw new BusinessException(ErrorCode.SKILL_ALREADY_EXISTS);
+			}
+		}
+
+		skill.updateName(request.name());
+	}
+
+}
+

--- a/backend/src/main/java/com/techeer/backend/api/skill/domain/Skill.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/domain/Skill.java
@@ -27,7 +27,7 @@ public class Skill extends BaseEntity {
 
 	@NotNull
 	@Size(max = 100)
-	@Column(name = "name", nullable = false, length = 100, unique = true)
+	@Column(name = "name", nullable = false, length = 100)
 	private String name;
 
 	@Builder

--- a/backend/src/main/java/com/techeer/backend/api/skill/domain/UserSkill.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/domain/UserSkill.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "user_skills",
-		uniqueConstraints = { @UniqueConstraint(name = "uk_user_skill", columnNames = { "user_id", "skill_id" }) })
+	uniqueConstraints = {@UniqueConstraint(name = "uk_user_skill", columnNames = {"user_id", "skill_id"})})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSkill extends BaseEntity {
 

--- a/backend/src/main/java/com/techeer/backend/api/skill/dto/request/SkillCreateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/dto/request/SkillCreateRequest.java
@@ -1,0 +1,9 @@
+package com.techeer.backend.api.skill.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SkillCreateRequest(
+	@NotBlank(message = "스킬명은 필수입니다") @Size(max = 100, message = "스킬명은 100자를 초과할 수 없습니다") String name) {
+}
+

--- a/backend/src/main/java/com/techeer/backend/api/skill/dto/request/SkillUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/dto/request/SkillUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.techeer.backend.api.skill.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record SkillUpdateRequest(@Size(max = 100, message = "스킬명은 100자를 초과할 수 없습니다") String name) {
+}
+

--- a/backend/src/main/java/com/techeer/backend/api/skill/dto/response/SkillInfoResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/skill/dto/response/SkillInfoResponse.java
@@ -1,0 +1,8 @@
+package com.techeer.backend.api.skill.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record SkillInfoResponse(Long id, String name) {
+}
+

--- a/backend/src/main/java/com/techeer/backend/api/user/adapter/in/web/UserController.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/adapter/in/web/UserController.java
@@ -47,7 +47,7 @@ public class UserController {
 	@Operation(summary = "자체 로그인", description = "이메일/비밀번호로 로그인합니다.")
 	@PostMapping("/auth/login")
 	public ResponseEntity<ApiResponse<Void>> login(@RequestBody @Valid LoginRequest request,
-			HttpServletResponse response) {
+												   HttpServletResponse response) {
 		userService.login(request, response);
 
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.USER_LOGIN_SUCCESS));
@@ -80,7 +80,7 @@ public class UserController {
 	@Operation(summary = "액세스 토큰 재발급")
 	@PostMapping("/reissue")
 	public ResponseEntity<ApiResponse<Void>> reGenerateAccessToken(
-			@CookieValue(value = "refreshToken", required = false) String refreshToken, HttpServletResponse response) {
+		@CookieValue(value = "refreshToken", required = false) String refreshToken, HttpServletResponse response) {
 
 		userService.reissueAccessToken(refreshToken, response);
 

--- a/backend/src/main/java/com/techeer/backend/api/user/converter/UserConverter.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/converter/UserConverter.java
@@ -15,7 +15,7 @@ public interface UserConverter {
 	@Mapping(source = "id", target = "userId")
 	@Mapping(source = "name", target = "username")
 	@Mapping(source = "profileImage.fileUrl", target = "profileImage",
-			nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
+		nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL)
 	UserInfoResponse toUserInfoResponse(User user);
 
 }

--- a/backend/src/main/java/com/techeer/backend/api/user/domain/User.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/domain/User.java
@@ -52,11 +52,11 @@ public class User extends BaseEntity {
 
 	@Embedded
 	@AttributeOverrides({
-			@AttributeOverride(name = "fileUrl",
-					column = @Column(name = "profile_image_url", columnDefinition = "TEXT")),
-			@AttributeOverride(name = "fileType", column = @Column(name = "profile_image_type")),
-			@AttributeOverride(name = "fileName", column = @Column(name = "profile_image_name")),
-			@AttributeOverride(name = "fileUUID", column = @Column(name = "profile_image_uuid")) })
+		@AttributeOverride(name = "fileUrl",
+			column = @Column(name = "profile_image_url", columnDefinition = "TEXT")),
+		@AttributeOverride(name = "fileType", column = @Column(name = "profile_image_type")),
+		@AttributeOverride(name = "fileName", column = @Column(name = "profile_image_name")),
+		@AttributeOverride(name = "fileUUID", column = @Column(name = "profile_image_uuid"))})
 	private File profileImage;
 
 	@Enumerated(EnumType.STRING)
@@ -69,7 +69,7 @@ public class User extends BaseEntity {
 
 	@Builder
 	public User(String email, String name, String password, String refreshToken, File profileImage, Role role,
-			SocialType socialType) {
+				SocialType socialType) {
 		this.email = email;
 		this.name = name;
 		this.password = password;

--- a/backend/src/main/java/com/techeer/backend/api/user/dto/request/LoginRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/dto/request/LoginRequest.java
@@ -5,5 +5,5 @@ import jakarta.validation.constraints.NotBlank;
 
 public record LoginRequest(@NotBlank(message = "이메일을 입력하세요") @Email(message = "올바른 이메일 형식이 아닙니다") String email,
 
-		@NotBlank(message = "비밀번호를 입력하세요") String password) {
+						   @NotBlank(message = "비밀번호를 입력하세요") String password) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/user/dto/request/RegisterRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/dto/request/RegisterRequest.java
@@ -7,9 +7,9 @@ import jakarta.validation.constraints.Size;
 
 public record RegisterRequest(@NotBlank(message = "이메일을 입력하세요") @Email(message = "올바른 이메일 형식이 아닙니다") String email,
 
-		@NotBlank(message = "이름을 입력하세요") String username,
+							  @NotBlank(message = "이름을 입력하세요") String username,
 
-		@NotBlank(message = "비밀번호를 입력하세요") @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다") @Pattern(
-				regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*#?&]{8,}$",
-				message = "비밀번호는 영문자와 숫자를 포함해야 합니다") String password) {
+							  @NotBlank(message = "비밀번호를 입력하세요") @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다") @Pattern(
+								  regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*#?&]{8,}$",
+								  message = "비밀번호는 영문자와 숫자를 포함해야 합니다") String password) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/user/dto/request/SignUpRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/dto/request/SignUpRequest.java
@@ -6,5 +6,5 @@ import jakarta.validation.constraints.NotNull;
 
 public record SignUpRequest(@NotBlank(message = "이름을 입력하세요") String name,
 
-		@NotNull(message = "권한을 입력하세요 (REGULAR, TECHEER, ADMIN)") Role role) {
+							@NotNull(message = "권한을 입력하세요 (REGULAR, TECHEER, ADMIN)") Role role) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/repository/UserRepository.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findByNameAndSocialType(String name, SocialType socialType); // 사용자
-																				// 이름으로
-																				// 사용자 찾기
+	// 이름으로
+	// 사용자 찾기
 
 	Optional<User> findByEmail(String email); // 이메일로 사용자 찾기
 

--- a/backend/src/main/java/com/techeer/backend/api/user/service/UserService.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/service/UserService.java
@@ -54,8 +54,7 @@ public class UserService {
 	}
 
 	/**
-	 * 자체 회원가입 (이메일/비밀번호) 비즈니스 로직: 이메일 중복 확인, 비밀번호 암호화, 사용자 생성 보안: 자체 회원가입 시 항상 REGULAR
-	 * 역할로 고정하여 권한 상승 방지
+	 * 자체 회원가입 (이메일/비밀번호) 비즈니스 로직: 이메일 중복 확인, 비밀번호 암호화, 사용자 생성 보안: 자체 회원가입 시 항상 REGULAR 역할로 고정하여 권한 상승 방지
 	 */
 	@Transactional
 	public void register(RegisterRequest request) {
@@ -152,7 +151,7 @@ public class UserService {
 
 		// 인증 정보가 없거나 인증되지 않은 경우
 		if (authentication == null || !authentication.isAuthenticated()
-				|| "anonymousUser".equals(authentication.getPrincipal())) {
+			|| "anonymousUser".equals(authentication.getPrincipal())) {
 			throw new BusinessException(ErrorCode.UNAUTHORIZED);
 		}
 
@@ -171,8 +170,7 @@ public class UserService {
 	/**
 	 * 액세스 토큰 재발급 비즈니스 로직: RefreshToken 검증, AccessToken 재발급, RefreshToken 갱신, 쿠키 설정
 	 * <p>
-	 * 주의: AccessToken이 만료된 상태에서 호출되므로 SecurityContext에서 사용자를 조회할 수 없습니다. 따라서
-	 * RefreshToken으로 DB에서 사용자를 조회합니다.
+	 * 주의: AccessToken이 만료된 상태에서 호출되므로 SecurityContext에서 사용자를 조회할 수 없습니다. 따라서 RefreshToken으로 DB에서 사용자를 조회합니다.
 	 */
 	@Transactional
 	public void reissueAccessToken(String refreshToken, HttpServletResponse response) {
@@ -261,8 +259,7 @@ public class UserService {
 	}
 
 	/**
-	 * 프로필 이미지 업데이트 비즈니스 로직: 현재 로그인한 사용자의 프로필 이미지를 GCS에 업로드하고 File 객체로 저장 기존 프로필 이미지가 있으면
-	 * GCS에서 삭제
+	 * 프로필 이미지 업데이트 비즈니스 로직: 현재 로그인한 사용자의 프로필 이미지를 GCS에 업로드하고 File 객체로 저장 기존 프로필 이미지가 있으면 GCS에서 삭제
 	 */
 	@Transactional
 	public String updateProfileImage(MultipartFile file) {
@@ -284,7 +281,7 @@ public class UserService {
 
 		// 기존 프로필 이미지가 있으면 GCS에서 삭제
 		if (user.getProfileImage() != null && user.getProfileImage().getFileUrl() != null
-				&& !user.getProfileImage().getFileUrl().isEmpty()) {
+			&& !user.getProfileImage().getFileUrl().isEmpty()) {
 			String oldImageUrl = user.getProfileImage().getFileUrl();
 			String oldGcsPath = extractGcsPathFromUrl(oldImageUrl);
 			if (oldGcsPath != null) {
@@ -310,15 +307,15 @@ public class UserService {
 		// @Transactional 내에서 엔티티 수정 시 변경 감지로 자동 저장
 
 		log.info("프로필 이미지 업데이트 완료: userId={}, profileImageUrl={}, fileType={}", user.getId(), fileMetadata.getFileUrl(),
-				fileType);
+			fileType);
 
 		return fileMetadata.getFileUrl();
 	}
 
 	/**
 	 * GCS URL에서 경로 추출 예:
-	 * https://storage.googleapis.com/download/storage/v1/b/bucket/o/profile%2Ffilename.png?generation=...
-	 * -> profile/filename.png
+	 * https://storage.googleapis.com/download/storage/v1/b/bucket/o/profile%2Ffilename.png?generation=... ->
+	 * profile/filename.png
 	 */
 	private String extractGcsPathFromUrl(String url) {
 		if (url == null || url.isEmpty()) {

--- a/backend/src/main/java/com/techeer/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/techeer/backend/global/error/ErrorCode.java
@@ -64,6 +64,7 @@ public enum ErrorCode {
 
 	// Skill Error
 	SKILL_NOT_FOUND(HttpStatus.NOT_FOUND, "SKILL_404", "스킬을 찾을 수 없습니다."),
+	SKILL_ALREADY_EXISTS(HttpStatus.CONFLICT, "SKILL_409", "이미 존재하는 스킬입니다."),
 	USER_SKILL_NOT_FOUND(HttpStatus.NOT_FOUND, "SKILL_404", "등록된 스킬을 찾을 수 없습니다."),
 	USER_SKILL_ALREADY_EXISTS(HttpStatus.CONFLICT, "SKILL_409", "이미 등록된 스킬입니다."),
 

--- a/backend/src/main/java/com/techeer/backend/global/success/SuccessCode.java
+++ b/backend/src/main/java/com/techeer/backend/global/success/SuccessCode.java
@@ -68,6 +68,12 @@ public enum SuccessCode implements BaseStatus {
 	USER_CAREER_UPDATE_SUCCESS(HttpStatus.OK, "CAREER_200", "경력이 수정되었습니다."),
 	USER_CAREER_DELETE_SUCCESS(HttpStatus.OK, "CAREER_200", "경력이 삭제되었습니다."),
 
+	// Skill Success
+	SKILL_CREATE_SUCCESS(HttpStatus.CREATED, "SKILL_201", "기술 스택이 등록되었습니다."),
+	SKILL_GET_SUCCESS(HttpStatus.OK, "SKILL_200", "기술 스택 조회에 성공했습니다."),
+	SKILL_UPDATE_SUCCESS(HttpStatus.OK, "SKILL_200", "기술 스택이 수정되었습니다."),
+	SKILL_DELETE_SUCCESS(HttpStatus.OK, "SKILL_200", "기술 스택이 삭제되었습니다."),
+
 	// UserSkill Success
 	USER_SKILL_CREATE_SUCCESS(HttpStatus.CREATED, "SKILL_201", "스킬이 등록되었습니다."),
 	USER_SKILL_DELETE_SUCCESS(HttpStatus.OK, "SKILL_200", "스킬이 삭제되었습니다."),


### PR DESCRIPTION
## 📋 개요

이 PR은 기술 스택(Skill) 관리 기능과 테스트 환경 구축을 위한 대량 Mock Data 생성 기능을 추가합니다.

## 🎯 주요 변경사항

### 1. Skill CRUD API 구현

#### 기능
- **등록**: 모든 사용자가 기술 스택 등록 가능
- **조회**: 기술 스택 단건 조회
- **수정**: 기술 스택명 수정
- **삭제**: Soft Delete 방식으로 삭제

#### 핵심 로직
- **대소문자 구분 없이 중복 체크**: "Java" 등록 후 "java" 또는 "JAVA" 등록 시도 시 `SKILL_409` 에러 발생
- **Soft Delete 지원**: 삭제된 스킬은 중복 체크에서 제외되어 재등록 가능
- **DB unique constraint 제거**: Soft Delete와의 충돌 방지를 위해 애플리케이션 레벨에서 중복 체크

#### API 엔드포인트
```
POST   /api/v1/skills          - 기술 스택 등록
GET    /api/v1/skills/{id}     - 기술 스택 조회
PUT    /api/v1/skills/{id}     - 기술 스택 수정
DELETE /api/v1/skills/{id}     - 기술 스택 삭제 (Soft Delete)
```

### 2. 대량 Mock Data 생성 스크립트

#### 목적
테스트 환경 구축을 위해 실 서비스 사례를 고려한 비율로 약 13,000개 이상의 레코드를 생성

#### 생성되는 데이터 규모
| 도메인          | 레코드 수       | 비고                                       |
| --------------- | --------------- | ------------------------------------------ |
| Users           | 1,000명         | ADMIN 10명, PREMIUM 40명, USER 950명       |
| Companies       | 150개           | 다양한 산업 분야                           |
| Company Members | 150개           | 각 기업당 1명 관리자                       |
| Job Postings    | 800개           | 기업당 평균 5-6개                          |
| User Files      | 2,700개         | Resume 900, Portfolio 700, Education 1,100 |
| Resumes         | 900개           | 각 사용자의 첫 번째 이력서는 기본값        |
| Portfolios      | 700개           | 각 사용자의 첫 번째 포트폴리오는 기본값    |
| Educations      | 1,100개         | 다양한 학력 정보                           |
| User Careers    | 1,800개         | 사용자당 평균 1.8개 경력                   |
| Applications    | 2,500개         | 사용자당 평균 2.5개 지원                   |
| Bookmarks       | 2,000개         | 사용자당 평균 2개 북마크                   |
| Company Likes   | 1,200개         | 사용자당 평균 1.2개 좋아요                 |
| User Skills     | 2,500개         | 사용자당 평균 2.5개 스킬                   |
| **총합**        | **약 13,000개** | Skills 제외                                |

#### 특징
- 실 서비스 비율 반영: 사용자 대비 기업, 채용공고, 지원 등의 비율을 반영
- 다양한 데이터 분포: 산업 분야, 직무, 상태 등 다양하게 생성
- 관계 무결성: 외래키 관계를 고려한 순서로 생성
- 중복 방지: Bookmarks, Company Likes, User Skills는 중복 방지 로직 포함
- Soft Delete 고려: `deleted_at IS NULL` 조건으로 활성 데이터만 조회

### Mock Data 스크립트

#### 파일 위치
- `backend/scripts/insert_mock_data.sql`
- `backend/docs/MOCK_DATA_GUIDE.md` (실행 가이드)

#### 실행 방법
```bash
# Docker 컨테이너를 통한 실행 (권장)
docker exec -i techeer-resume-mysql-1 mysql -uroot -proot techeer < backend/scripts/insert_mock_data.sql

# MySQL 클라이언트를 통한 실행
mysql -uroot -proot -h127.0.0.1 -P3306 techeer < backend/scripts/insert_mock_data.sql
```

## ✅ 테스트

### Skill API 테스트 결과

#### 1. 기술 스택 등록
```bash
curl -X POST http://localhost:8080/api/v1/skills \
  -H "Content-Type: application/json" \
  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
  -d '{"name": "Java"}'
# ✅ 성공: {"success":true,"message":"기술 스택이 등록되었습니다.","data":1}
```

#### 2. 중복 등록 방지 (대소문자 구분 없이)
```bash
curl -X POST http://localhost:8080/api/v1/skills \
  -H "Content-Type: application/json" \
  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
  -d '{"name": "java"}'
# ✅ 에러: {"http_status":"CONFLICT","code":"SKILL_409","error_message":"이미 존재하는 스킬입니다."}
```

#### 3. 기술 스택 조회
```bash
curl -X GET http://localhost:8080/api/v1/skills/1 \
  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN"
# ✅ 성공: {"success":true,"message":"기술 스택 조회에 성공했습니다.","data":{"id":1,"name":"Java"}}
```

#### 4. 기술 스택 수정
```bash
curl -X PUT http://localhost:8080/api/v1/skills/1 \
  -H "Content-Type: application/json" \
  -H "Cookie: accessToken=YOUR_ACCESS_TOKEN" \
  -d '{"name": "Java 17"}'
# ✅ 성공: {"success":true,"message":"기술 스택이 수정되었습니다."}
```

### Mock Data 스크립트 테스트

```bash
# 스크립트 실행
docker exec -i techeer-resume-mysql-1 mysql -uroot -proot techeer < backend/scripts/insert_mock_data.sql

# 결과 확인
# 스크립트 마지막에 자동으로 통계 쿼리가 실행되어 각 테이블의 레코드 수를 확인할 수 있습니다.
```

### Mock Data 스크립트 실행 전

1. **Skills 데이터 확인**: `user_skills` 테이블에 데이터를 생성하기 위해서는 `skills` 테이블에 최소 1개 이상의 데이터가 있어야 합니다.
2. **기존 데이터 보존**: 스크립트는 기존 데이터를 삭제하지 않고 추가만 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive skills management API endpoints for create, retrieve, update, and delete operations.
  * Enhanced API documentation with detailed curl command examples, field mappings, and snake_case conversion guidance.

* **Documentation**
  * Created mock data generation guide for populating test environments with large-scale sample data.
  * Added DTO formatting conventions documentation for API integration reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->