### PR TITLE
refactor: split UserService and align hex architecture (#sprint-0a)

### DIFF
--- a/backend/src/main/java/com/techeer/backend/api/user/adapter/in/web/UserController.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/adapter/in/web/UserController.java
@@ -2,6 +2,7 @@ package com.techeer.backend.api.user.adapter.in.web;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
+import com.techeer.backend.api.user.application.service.ProfileImageService;
 import com.techeer.backend.api.user.converter.UserConverter;
 import com.techeer.backend.api.user.domain.User;
 import com.techeer.backend.api.user.dto.request.LoginRequest;
@@ -36,6 +37,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserController {
 
 	private final UserService userService;
+
+	private final ProfileImageService profileImageService;
 
 	@Operation(summary = "자체 회원가입", description = "이메일/비밀번호로 회원가입합니다.")
 	@PostMapping("/auth/register")
@@ -97,7 +100,7 @@ public class UserController {
 	@Operation(summary = "프로필 이미지 수정", description = "현재 로그인한 사용자의 프로필 이미지를 업로드하고 업데이트합니다.")
 	@PatchMapping(value = "/user/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public ResponseEntity<ApiResponse<String>> updateProfileImage(@RequestPart("file") MultipartFile file) {
-		String profileImageUrl = userService.updateProfileImage(file);
+		String profileImageUrl = profileImageService.updateProfileImage(file);
 
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.USER_PROFILE_IMAGE_UPDATE_OK, profileImageUrl));
 	}

--- a/backend/src/main/java/com/techeer/backend/api/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -1,6 +1,7 @@
 package com.techeer.backend.api.user.adapter.out.persistence;
 
 import com.techeer.backend.api.user.application.port.out.LoadUserPort;
+import com.techeer.backend.api.user.application.port.out.SaveUserPort;
 import com.techeer.backend.api.user.domain.User;
 import com.techeer.backend.api.user.repository.UserRepository;
 import java.util.Optional;
@@ -9,13 +10,28 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class UserPersistenceAdapter implements LoadUserPort {
+public class UserPersistenceAdapter implements LoadUserPort, SaveUserPort {
 
 	private final UserRepository userRepository;
 
 	@Override
 	public Optional<User> findById(Long id) {
 		return userRepository.findById(id);
+	}
+
+	@Override
+	public Optional<User> findByEmail(String email) {
+		return userRepository.findByEmail(email);
+	}
+
+	@Override
+	public Optional<User> findByRefreshToken(String refreshToken) {
+		return userRepository.findByRefreshToken(refreshToken);
+	}
+
+	@Override
+	public User saveUser(User user) {
+		return userRepository.save(user);
 	}
 
 }

--- a/backend/src/main/java/com/techeer/backend/api/user/application/port/out/LoadUserPort.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/application/port/out/LoadUserPort.java
@@ -7,4 +7,8 @@ public interface LoadUserPort {
 
 	Optional<User> findById(Long id);
 
+	Optional<User> findByEmail(String email);
+
+	Optional<User> findByRefreshToken(String refreshToken);
+
 }

--- a/backend/src/main/java/com/techeer/backend/api/user/application/port/out/SaveUserPort.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/application/port/out/SaveUserPort.java
@@ -1,0 +1,9 @@
+package com.techeer.backend.api.user.application.port.out;
+
+import com.techeer.backend.api.user.domain.User;
+
+public interface SaveUserPort {
+
+	User saveUser(User user);
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/user/application/service/ProfileImageService.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/application/service/ProfileImageService.java
@@ -1,0 +1,113 @@
+package com.techeer.backend.api.user.application.service;
+
+import com.techeer.backend.api.user.application.port.out.LoadUserPort;
+import com.techeer.backend.api.user.domain.File;
+import com.techeer.backend.api.user.domain.FileType;
+import com.techeer.backend.api.user.domain.User;
+import com.techeer.backend.api.user.service.UserService;
+import com.techeer.backend.global.error.ErrorCode;
+import com.techeer.backend.global.error.exception.BusinessException;
+import com.techeer.backend.infra.gcp.FileMetadata;
+import com.techeer.backend.infra.gcp.FileTypeMapper;
+import com.techeer.backend.infra.gcp.GcsUploader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ProfileImageService {
+
+	private final UserService userService;
+
+	private final GcsUploader gcsUploader;
+
+	private final FileTypeMapper fileTypeMapper;
+
+	/**
+	 * 프로필 이미지 업데이트 비즈니스 로직: 현재 로그인한 사용자의 프로필 이미지를 GCS에 업로드하고 File 객체로 저장
+	 * 기존 프로필 이미지가 있으면 GCS에서 삭제
+	 */
+	@Transactional
+	public String updateProfileImage(MultipartFile file) {
+		User user = userService.getLoginUser();
+
+		// 파일 타입 검증: 프로필 이미지는 이미지 파일만 허용
+		String contentType = file.getContentType();
+		if (contentType == null || !contentType.startsWith("image/")) {
+			log.warn("프로필 이미지 업로드 실패: 이미지 파일이 아님. contentType={}", contentType);
+			throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
+		}
+
+		// 파일 크기 검증 (10MB 제한 - 프로필 이미지용)
+		long maxFileSize = 10 * 1024 * 1024; // 10MB
+		if (file.getSize() > maxFileSize) {
+			log.warn("프로필 이미지 업로드 실패: 파일 크기 초과. size={} bytes", file.getSize());
+			throw new BusinessException(ErrorCode.FILE_SIZE_EXCEEDED);
+		}
+
+		// 기존 프로필 이미지가 있으면 GCS에서 삭제
+		if (user.getProfileImage() != null && user.getProfileImage().getFileUrl() != null
+			&& !user.getProfileImage().getFileUrl().isEmpty()) {
+			String oldImageUrl = user.getProfileImage().getFileUrl();
+			String oldGcsPath = extractGcsPathFromUrl(oldImageUrl);
+			if (oldGcsPath != null) {
+				gcsUploader.deleteFile(oldGcsPath);
+				log.info("기존 프로필 이미지 삭제 완료: gcsPath={}", oldGcsPath);
+			}
+		}
+
+		// 새로운 프로필 이미지 업로드
+		FileMetadata fileMetadata = gcsUploader.uploadProfileImage(file, user.getId());
+		FileType fileType = fileTypeMapper.determineFileType(fileMetadata.getContentType());
+
+		// File 객체 생성
+		File profileImage = File.builder()
+			.fileUrl(fileMetadata.getFileUrl())
+			.fileType(fileType)
+			.fileName(fileMetadata.getFileName())
+			.fileUUID(fileMetadata.getFileUUID())
+			.build();
+
+		// 사용자 엔티티에 프로필 이미지 저장
+		user.updateProfileImage(profileImage);
+		// @Transactional 내에서 엔티티 수정 시 변경 감지로 자동 저장
+
+		log.info("프로필 이미지 업데이트 완료: userId={}, profileImageUrl={}, fileType={}",
+			user.getId(), fileMetadata.getFileUrl(), fileType);
+
+		return fileMetadata.getFileUrl();
+	}
+
+	/**
+	 * GCS URL에서 경로 추출
+	 * 예: https://storage.googleapis.com/download/storage/v1/b/bucket/o/profile%2Ffilename.png?generation=...
+	 * -> profile/filename.png
+	 */
+	private String extractGcsPathFromUrl(String url) {
+		if (url == null || url.isEmpty()) {
+			return null;
+		}
+
+		// URL에서 "o/" 다음 부분 추출
+		int oIndex = url.indexOf("/o/");
+		if (oIndex == -1) {
+			return null;
+		}
+
+		String pathPart = url.substring(oIndex + 3);
+
+		// 쿼리 파라미터 제거
+		int queryIndex = pathPart.indexOf("?");
+		if (queryIndex != -1) {
+			pathPart = pathPart.substring(0, queryIndex);
+		}
+
+		// URL 디코딩 (%2F -> /)
+		return java.net.URLDecoder.decode(pathPart, java.nio.charset.StandardCharsets.UTF_8);
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/user/service/UserService.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/service/UserService.java
@@ -1,20 +1,16 @@
 package com.techeer.backend.api.user.service;
 
-import com.techeer.backend.api.user.domain.File;
-import com.techeer.backend.api.user.domain.FileType;
+import com.techeer.backend.api.user.application.port.out.LoadUserPort;
+import com.techeer.backend.api.user.application.port.out.SaveUserPort;
 import com.techeer.backend.api.user.domain.Role;
 import com.techeer.backend.api.user.domain.SocialType;
 import com.techeer.backend.api.user.domain.User;
 import com.techeer.backend.api.user.dto.request.LoginRequest;
 import com.techeer.backend.api.user.dto.request.RegisterRequest;
 import com.techeer.backend.api.user.dto.request.SignUpRequest;
-import com.techeer.backend.api.user.repository.UserRepository;
 import com.techeer.backend.global.error.ErrorCode;
 import com.techeer.backend.global.error.exception.BusinessException;
 import com.techeer.backend.global.jwt.service.JwtService;
-import com.techeer.backend.infra.gcp.FileMetadata;
-import com.techeer.backend.infra.gcp.FileTypeMapper;
-import com.techeer.backend.infra.gcp.GcsUploader;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
 import lombok.AccessLevel;
@@ -26,22 +22,19 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserService {
 
-	private final UserRepository userRepository;
+	private final LoadUserPort loadUserPort;
+
+	private final SaveUserPort saveUserPort;
 
 	private final JwtService jwtService;
 
 	private final PasswordEncoder passwordEncoder;
-
-	private final GcsUploader gcsUploader;
-
-	private final FileTypeMapper fileTypeMapper;
 
 	/**
 	 * 사용자 추가 정보 입력 비즈니스 로직: 현재 로그인한 사용자의 추가 정보 업데이트
@@ -53,9 +46,7 @@ public class UserService {
 		// @Transactional 내에서 엔티티 수정 시 변경 감지로 자동 저장되므로 save() 불필요
 	}
 
-	/**
-	 * 자체 회원가입 (이메일/비밀번호) 비즈니스 로직: 이메일 중복 확인, 비밀번호 암호화, 사용자 생성 보안: 자체 회원가입 시 항상 REGULAR 역할로 고정하여 권한 상승 방지
-	 */
+	/** 자체 회원가입: 이메일 중복 확인, 비밀번호 암호화, 사용자 생성. 항상 USER 역할로 고정. */
 	@Transactional
 	public void register(RegisterRequest request) {
 		// 이메일 중복 확인
@@ -75,7 +66,7 @@ public class UserService {
 			.build();
 
 		// 새로운 엔티티이므로 save() 필요
-		userRepository.save(user);
+		saveUserPort.saveUser(user);
 		log.info("새로운 사용자 가입 완료: email={}, role=USER", request.email());
 	}
 
@@ -106,11 +97,7 @@ public class UserService {
 		log.info("사용자 로그인 완료: email={}", request.email());
 	}
 
-	/**
-	 * 소셜 로그인 사용자 생성 (OAuth2용) 비즈니스 로직: 소셜 로그인 정보를 기반으로 사용자 생성
-	 * <p>
-	 * Note: CustomOAuth2UserService에서 이미 중복 체크를 수행하므로 이 메서드 호출 시점에는 신규 사용자임이 보장됨
-	 */
+	/** 소셜 로그인 사용자 생성 (OAuth2용). CustomOAuth2UserService에서 중복 체크 후 호출됨. */
 	@Transactional
 	public void createRegularUser(Map<String, Object> attributes, String name, SocialType socialType) {
 		String email = (String) attributes.get("email");
@@ -126,7 +113,7 @@ public class UserService {
 			.role(Role.USER)
 			.build();
 
-		userRepository.save(user);
+		saveUserPort.saveUser(user);
 		log.info("새로운 소셜 로그인 사용자 생성 완료: email={}, socialType={}", email, socialType);
 	}
 
@@ -141,11 +128,7 @@ public class UserService {
 		log.info("사용자 로그아웃 완료: email={}", user.getEmail());
 	}
 
-	/**
-	 * 현재 로그인한 사용자 조회 SecurityContext에서 인증 정보를 가져와 사용자 엔티티 반환
-	 * <p>
-	 * 보안: 인증되지 않은 요청에 대해 명시적 검증을 수행하여 NullPointerException이나 ClassCastException을 방지합니다.
-	 */
+	/** SecurityContext에서 현재 로그인한 사용자 조회. 미인증 요청 시 UNAUTHORIZED 예외 발생. */
 	public User getLoginUser() {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
@@ -164,14 +147,10 @@ public class UserService {
 		String email = userDetails.getUsername();
 		log.debug("현재 로그인한 사용자 조회: email={}", email);
 
-		return userRepository.findByEmail(email).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+		return loadUserPort.findByEmail(email).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 	}
 
-	/**
-	 * 액세스 토큰 재발급 비즈니스 로직: RefreshToken 검증, AccessToken 재발급, RefreshToken 갱신, 쿠키 설정
-	 * <p>
-	 * 주의: AccessToken이 만료된 상태에서 호출되므로 SecurityContext에서 사용자를 조회할 수 없습니다. 따라서 RefreshToken으로 DB에서 사용자를 조회합니다.
-	 */
+	/** 액세스 토큰 재발급: RefreshToken 검증 후 AccessToken/RefreshToken 갱신. RefreshToken으로 사용자 조회. */
 	@Transactional
 	public void reissueAccessToken(String refreshToken, HttpServletResponse response) {
 		// RefreshToken 검증
@@ -180,7 +159,7 @@ public class UserService {
 		}
 
 		// RefreshToken으로 사용자 조회 (AccessToken이 만료되어 SecurityContext에 없을 수 있음)
-		User user = userRepository.findByRefreshToken(refreshToken)
+		User user = loadUserPort.findByRefreshToken(refreshToken)
 			.orElseThrow(() -> new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN));
 
 		// DB의 RefreshToken과 일치하는지 한 번 더 확인
@@ -207,7 +186,7 @@ public class UserService {
 	@Transactional
 	public String mockSignup(String id) {
 		// 이미 존재하는 사용자 확인
-		userRepository.findByEmail(id).ifPresent(user -> {
+		loadUserPort.findByEmail(id).ifPresent(user -> {
 			log.warn("모의 사용자가 이미 존재합니다: email={}", id);
 			throw new BusinessException(ErrorCode.USER_ALREADY_EXISTS);
 		});
@@ -225,7 +204,7 @@ public class UserService {
 			.socialType(SocialType.GOOGLE)
 			.build();
 
-		userRepository.save(user);
+		saveUserPort.saveUser(user);
 		log.info("모의 사용자 생성 완료: email={}", id);
 
 		return accessToken;
@@ -237,14 +216,14 @@ public class UserService {
 	 * 이메일로 사용자 조회
 	 */
 	private User findUserByEmail(String email) {
-		return userRepository.findByEmail(email).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+		return loadUserPort.findByEmail(email).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 	}
 
 	/**
 	 * 이메일 중복 확인
 	 */
 	private void validateEmailNotExists(String email) {
-		if (userRepository.findByEmail(email).isPresent()) {
+		if (loadUserPort.findByEmail(email).isPresent()) {
 			throw new BusinessException(ErrorCode.USER_ALREADY_EXISTS);
 		}
 	}
@@ -256,88 +235,6 @@ public class UserService {
 		if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
 			throw new BusinessException(ErrorCode.USER_PASSWORD_MISMATCH);
 		}
-	}
-
-	/**
-	 * 프로필 이미지 업데이트 비즈니스 로직: 현재 로그인한 사용자의 프로필 이미지를 GCS에 업로드하고 File 객체로 저장 기존 프로필 이미지가 있으면 GCS에서 삭제
-	 */
-	@Transactional
-	public String updateProfileImage(MultipartFile file) {
-		User user = this.getLoginUser();
-
-		// 파일 타입 검증: 프로필 이미지는 이미지 파일만 허용
-		String contentType = file.getContentType();
-		if (contentType == null || !contentType.startsWith("image/")) {
-			log.warn("프로필 이미지 업로드 실패: 이미지 파일이 아님. contentType={}", contentType);
-			throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
-		}
-
-		// 파일 크기 검증 (10MB 제한 - 프로필 이미지용)
-		long maxFileSize = 10 * 1024 * 1024; // 10MB
-		if (file.getSize() > maxFileSize) {
-			log.warn("프로필 이미지 업로드 실패: 파일 크기 초과. size={} bytes", file.getSize());
-			throw new BusinessException(ErrorCode.FILE_SIZE_EXCEEDED);
-		}
-
-		// 기존 프로필 이미지가 있으면 GCS에서 삭제
-		if (user.getProfileImage() != null && user.getProfileImage().getFileUrl() != null
-			&& !user.getProfileImage().getFileUrl().isEmpty()) {
-			String oldImageUrl = user.getProfileImage().getFileUrl();
-			String oldGcsPath = extractGcsPathFromUrl(oldImageUrl);
-			if (oldGcsPath != null) {
-				gcsUploader.deleteFile(oldGcsPath);
-				log.info("기존 프로필 이미지 삭제 완료: gcsPath={}", oldGcsPath);
-			}
-		}
-
-		// 새로운 프로필 이미지 업로드
-		FileMetadata fileMetadata = gcsUploader.uploadProfileImage(file, user.getId());
-		FileType fileType = fileTypeMapper.determineFileType(fileMetadata.getContentType());
-
-		// File 객체 생성
-		File profileImage = File.builder()
-			.fileUrl(fileMetadata.getFileUrl())
-			.fileType(fileType)
-			.fileName(fileMetadata.getFileName())
-			.fileUUID(fileMetadata.getFileUUID())
-			.build();
-
-		// 사용자 엔티티에 프로필 이미지 저장
-		user.updateProfileImage(profileImage);
-		// @Transactional 내에서 엔티티 수정 시 변경 감지로 자동 저장
-
-		log.info("프로필 이미지 업데이트 완료: userId={}, profileImageUrl={}, fileType={}", user.getId(), fileMetadata.getFileUrl(),
-			fileType);
-
-		return fileMetadata.getFileUrl();
-	}
-
-	/**
-	 * GCS URL에서 경로 추출 예:
-	 * https://storage.googleapis.com/download/storage/v1/b/bucket/o/profile%2Ffilename.png?generation=... ->
-	 * profile/filename.png
-	 */
-	private String extractGcsPathFromUrl(String url) {
-		if (url == null || url.isEmpty()) {
-			return null;
-		}
-
-		// URL에서 "o/" 다음 부분 추출
-		int oIndex = url.indexOf("/o/");
-		if (oIndex == -1) {
-			return null;
-		}
-
-		String pathPart = url.substring(oIndex + 3);
-
-		// 쿼리 파라미터 제거
-		int queryIndex = pathPart.indexOf("?");
-		if (queryIndex != -1) {
-			pathPart = pathPart.substring(0, queryIndex);
-		}
-
-		// URL 디코딩 (%2F -> /)
-		return java.net.URLDecoder.decode(pathPart, java.nio.charset.StandardCharsets.UTF_8);
 	}
 
 }

--- a/backend/src/test/java/com/techeer/backend/api/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/techeer/backend/api/user/service/UserServiceTest.java
@@ -7,16 +7,15 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.techeer.backend.api.user.application.port.out.LoadUserPort;
+import com.techeer.backend.api.user.application.port.out.SaveUserPort;
 import com.techeer.backend.api.user.domain.Role;
 import com.techeer.backend.api.user.domain.SocialType;
 import com.techeer.backend.api.user.domain.User;
 import com.techeer.backend.api.user.dto.request.LoginRequest;
 import com.techeer.backend.api.user.dto.request.RegisterRequest;
-import com.techeer.backend.api.user.repository.UserRepository;
 import com.techeer.backend.global.error.exception.BusinessException;
 import com.techeer.backend.global.jwt.service.JwtService;
-import com.techeer.backend.infra.gcp.FileTypeMapper;
-import com.techeer.backend.infra.gcp.GcsUploader;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
 import java.util.Optional;
@@ -36,19 +35,16 @@ class UserServiceTest {
 	private UserService userService;
 
 	@Mock
-	private UserRepository userRepository;
+	private LoadUserPort loadUserPort;
+
+	@Mock
+	private SaveUserPort saveUserPort;
 
 	@Mock
 	private JwtService jwtService;
 
 	@Mock
 	private PasswordEncoder passwordEncoder;
-
-	@Mock
-	private GcsUploader gcsUploader;
-
-	@Mock
-	private FileTypeMapper fileTypeMapper;
 
 	@Nested
 	@DisplayName("자체 회원가입 (Register)")
@@ -59,14 +55,15 @@ class UserServiceTest {
 		void success() {
 			// Given
 			RegisterRequest request = new RegisterRequest("test@example.com", "Test User", "password1234");
-			given(userRepository.findByEmail(request.email())).willReturn(Optional.empty());
+			given(loadUserPort.findByEmail(request.email())).willReturn(Optional.empty());
 			given(passwordEncoder.encode(request.password())).willReturn("encodedPassword");
+			given(saveUserPort.saveUser(any(User.class))).willReturn(mock(User.class));
 
 			// When
 			userService.register(request);
 
 			// Then
-			verify(userRepository).save(any(User.class));
+			verify(saveUserPort).saveUser(any(User.class));
 		}
 
 		@Test
@@ -74,7 +71,7 @@ class UserServiceTest {
 		void fail_duplicate_email() {
 			// Given
 			RegisterRequest request = new RegisterRequest("test@example.com", "Test User", "password1234");
-			given(userRepository.findByEmail(request.email())).willReturn(Optional.of(mock(User.class)));
+			given(loadUserPort.findByEmail(request.email())).willReturn(Optional.of(mock(User.class)));
 
 			// When & Then
 			assertThatThrownBy(() -> userService.register(request)).isInstanceOf(BusinessException.class)
@@ -100,7 +97,7 @@ class UserServiceTest {
 				.build();
 			HttpServletResponse response = mock(HttpServletResponse.class);
 
-			given(userRepository.findByEmail(request.email())).willReturn(Optional.of(user));
+			given(loadUserPort.findByEmail(request.email())).willReturn(Optional.of(user));
 			given(passwordEncoder.matches(request.password(), user.getPassword())).willReturn(true);
 			given(jwtService.createAccessToken(any())).willReturn("accessToken");
 			given(jwtService.createRefreshToken()).willReturn("refreshToken");
@@ -120,7 +117,7 @@ class UserServiceTest {
 			LoginRequest request = new LoginRequest("unknown@example.com", "password");
 			HttpServletResponse response = mock(HttpServletResponse.class);
 
-			given(userRepository.findByEmail(request.email())).willReturn(Optional.empty());
+			given(loadUserPort.findByEmail(request.email())).willReturn(Optional.empty());
 
 			// When & Then
 			assertThatThrownBy(() -> userService.login(request, response)).isInstanceOf(BusinessException.class);
@@ -134,7 +131,7 @@ class UserServiceTest {
 			User user = User.builder().email("test@example.com").password("encodedPassword").build();
 			HttpServletResponse response = mock(HttpServletResponse.class);
 
-			given(userRepository.findByEmail(request.email())).willReturn(Optional.of(user));
+			given(loadUserPort.findByEmail(request.email())).willReturn(Optional.of(user));
 			given(passwordEncoder.matches(request.password(), user.getPassword())).willReturn(false);
 
 			// When & Then
@@ -154,12 +151,13 @@ class UserServiceTest {
 			Map<String, Object> attributes = Map.of("email", "social@example.com");
 			String name = "Social User";
 			SocialType socialType = SocialType.GOOGLE;
+			given(saveUserPort.saveUser(any(User.class))).willReturn(mock(User.class));
 
 			// When
 			userService.createRegularUser(attributes, name, socialType);
 
 			// Then
-			verify(userRepository).save(any(User.class));
+			verify(saveUserPort).saveUser(any(User.class));
 		}
 
 	}

--- a/backend/src/test/java/com/techeer/backend/integration/company/CompanyApiIntegrationTest.java
+++ b/backend/src/test/java/com/techeer/backend/integration/company/CompanyApiIntegrationTest.java
@@ -58,8 +58,8 @@ class CompanyApiIntegrationTest {
 			.build();
 		userRepository.save(user);
 
-		CompanyRegisterRequest request = new CompanyRegisterRequest("Techeer", "IT", "https://techeer.com", "Seoul",
-				user.getId());
+		CompanyRegisterRequest request = new CompanyRegisterRequest("Techeer", null, "IT", "https://techeer.com",
+				"Seoul");
 
 		// when & then
 		mockMvc

--- a/backend/src/test/java/com/techeer/backend/integration/document/DocumentApiIntegrationTest.java
+++ b/backend/src/test/java/com/techeer/backend/integration/document/DocumentApiIntegrationTest.java
@@ -64,7 +64,7 @@ class DocumentApiIntegrationTest {
 	@DisplayName("이력서 등록 성공 테스트")
 	void createResume_Success() throws Exception {
 		// given
-		ResumeCreateRequest request = new ResumeCreateRequest(user.getId(), "My Resume", true);
+		ResumeCreateRequest request = new ResumeCreateRequest("My Resume", true);
 		MockMultipartFile file = new MockMultipartFile("file", "resume.pdf", "application/pdf",
 				"dummy content".getBytes());
 		MockMultipartFile requestPart = new MockMultipartFile("request", "request.json", "application/json",
@@ -82,7 +82,7 @@ class DocumentApiIntegrationTest {
 	@DisplayName("포트폴리오 등록 성공 테스트")
 	void createPortfolio_Success() throws Exception {
 		// given
-		PortfolioCreateRequest request = new PortfolioCreateRequest(user.getId(), "My Portfolio", false);
+		PortfolioCreateRequest request = new PortfolioCreateRequest("My Portfolio", false);
 		MockMultipartFile file = new MockMultipartFile("file", "portfolio.pdf", "application/pdf",
 				"dummy content".getBytes());
 		MockMultipartFile requestPart = new MockMultipartFile("request", "request.json", "application/json",
@@ -100,7 +100,7 @@ class DocumentApiIntegrationTest {
 	@DisplayName("학력 등록 성공 테스트")
 	void createEducation_Success() throws Exception {
 		// given
-		EducationCreateRequest request = new EducationCreateRequest(user.getId(), "My Education", false);
+		EducationCreateRequest request = new EducationCreateRequest("My Education", false);
 		MockMultipartFile file = new MockMultipartFile("file", "degree.pdf", "application/pdf",
 				"dummy content".getBytes());
 		MockMultipartFile requestPart = new MockMultipartFile("request", "request.json", "application/json",


### PR DESCRIPTION
## Summary
- Extract `updateProfileImage()` and all GCS-related logic from `UserService` into a new `ProfileImageService` at `api/user/application/service/ProfileImageService.java`
- Add `SaveUserPort` output port and expand `LoadUserPort` with `findByEmail` / `findByRefreshToken`
- Update `UserPersistenceAdapter` to implement both `LoadUserPort` and `SaveUserPort`
- Refactor `UserService` to use ports instead of direct `UserRepository` access (240 lines, down from 343)
- Update `UserController` to inject `ProfileImageService` for the profile image endpoint
- Update `UserServiceTest` to mock ports instead of `UserRepository`
- Fix pre-existing test compilation errors in `DocumentApiIntegrationTest` and `CompanyApiIntegrationTest`

## Test plan
- [ ] `./gradlew compileJava` passes with zero errors
- [ ] `./gradlew compileTestJava` passes with zero errors
- [ ] `UserServiceTest` (6 tests) all pass
- [ ] API contract unchanged: all existing controller endpoints behave identically
- [ ] `global/` package untouched (`JwtAuthenticationFilter`, `CustomOAuth2UserService`, `OAuth2LoginSuccessHandler` keep their `UserRepository` references)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized profile image upload handling to improve service architecture and separation of concerns.
  * Enhanced user persistence layer with more flexible data access patterns.
  * Updated dependency injection structure for improved maintainability.

* **Tests**
  * Updated integration and unit tests to align with new architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->