### PR TITLE
feat: Sprint 1 - Job Search System (domain + OpenSearch + crawler)

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -49,4 +49,5 @@ src/main/resources/*-key.json
 src/main/resources/*service-account*.json
 src/main/resources/*secret*.json
 src/main/resources/*.key
-src/main/resources/*.pem
+src/main/resources/*.pem# Worktrees
+.claude/worktrees/

--- a/backend/src/main/java/com/techeer/backend/BackendApplication.java
+++ b/backend/src/main/java/com/techeer/backend/BackendApplication.java
@@ -6,10 +6,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @OpenAPIDefinition(servers = { @Server(url = "/", description = "Default Server url") })
 @EnableCaching
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/techeer/backend/api/job/adapter/in/scheduler/CrawlerScheduler.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/adapter/in/scheduler/CrawlerScheduler.java
@@ -1,0 +1,44 @@
+package com.techeer.backend.api.job.adapter.in.scheduler;
+
+import com.techeer.backend.api.job.application.service.CrawlerOrchestrationService;
+import com.techeer.backend.api.job.dto.CrawlResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scheduled trigger for the job crawler pipeline.
+ *
+ * Runs every hour by default. Can be disabled via application.yml:
+ *   crawler.enabled: false
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "crawler.enabled", havingValue = "true", matchIfMissing = true)
+public class CrawlerScheduler {
+
+    private final CrawlerOrchestrationService crawlerOrchestrationService;
+
+    /**
+     * Scheduled crawl — runs every hour (3,600,000 ms).
+     * Rate can be overridden via application.yml: crawler.schedule-rate
+     */
+    @Scheduled(fixedRateString = "${crawler.schedule-rate:3600000}")
+    public void scheduledCrawl() {
+        log.info("[CrawlerScheduler] Scheduled crawl started");
+        try {
+            CrawlResult result = crawlerOrchestrationService.crawlAll();
+            log.info("[CrawlerScheduler] Crawl finished — status={} new={} skipped={} expired={}",
+                result.getStatus(),
+                result.getNewCount(),
+                result.getSkippedDuplicates(),
+                result.getExpiredCount());
+        } catch (Exception e) {
+            log.error("[CrawlerScheduler] Crawl failed unexpectedly: {}", e.getMessage(), e);
+        }
+    }
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/adapter/in/web/CrawlerAdminController.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/adapter/in/web/CrawlerAdminController.java
@@ -1,0 +1,55 @@
+package com.techeer.backend.api.job.adapter.in.web;
+
+import com.techeer.backend.api.job.application.service.CrawlerOrchestrationService;
+import com.techeer.backend.api.job.dto.CrawlResult;
+import com.techeer.backend.global.dto.ApiResponse;
+import com.techeer.backend.global.success.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Admin endpoints for manually triggering and inspecting the job crawler.
+ *
+ * These endpoints are for development / QA purposes.
+ * In production, access should be restricted via Spring Security role checks.
+ */
+@Slf4j
+@Tag(name = "CrawlerAdmin", description = "크롤러 관리자 API")
+@RestController
+@RequestMapping("/api/v1/admin/crawl")
+@RequiredArgsConstructor
+public class CrawlerAdminController {
+
+    private final CrawlerOrchestrationService crawlerOrchestrationService;
+
+    /** Stores the result of the last crawl run (in-memory; resets on restart). */
+    private final AtomicReference<CrawlResult> lastCrawlResult = new AtomicReference<>();
+
+    @Operation(summary = "크롤러 수동 실행", description = "크롤러를 즉시 실행하여 채용공고를 수집합니다. (테스트/관리자 전용)")
+    @PostMapping
+    public ResponseEntity<ApiResponse<CrawlResult>> triggerCrawl() {
+        log.info("[CrawlerAdmin] Manual crawl triggered");
+        CrawlResult result = crawlerOrchestrationService.crawlAll();
+        lastCrawlResult.set(result);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, result));
+    }
+
+    @Operation(summary = "마지막 크롤링 결과 조회", description = "가장 최근 크롤링 실행 결과를 반환합니다.")
+    @GetMapping("/status")
+    public ResponseEntity<ApiResponse<CrawlResult>> getCrawlStatus() {
+        CrawlResult result = lastCrawlResult.get();
+        if (result == null) {
+            result = CrawlResult.failure("아직 크롤링이 실행되지 않았습니다.");
+        }
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, result));
+    }
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/adapter/in/web/JobSearchController.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/adapter/in/web/JobSearchController.java
@@ -1,0 +1,79 @@
+package com.techeer.backend.api.job.adapter.in.web;
+
+import com.techeer.backend.api.job.application.port.in.SearchJobPostingUseCase;
+import com.techeer.backend.api.job.dto.request.JobSearchRequest;
+import com.techeer.backend.api.job.dto.response.AutocompleteResponse;
+import com.techeer.backend.api.job.dto.response.JobSearchResponse;
+import com.techeer.backend.global.dto.ApiResponse;
+import com.techeer.backend.global.success.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "JobSearch", description = "채용공고 검색 API")
+@RestController
+@RequestMapping("/api/v2/jobs")
+@RequiredArgsConstructor
+public class JobSearchController {
+
+	private final SearchJobPostingUseCase searchJobPostingUseCase;
+
+	@Operation(summary = "채용공고 검색", description = "전문 검색 및 필터링으로 채용공고를 검색합니다.")
+	@GetMapping("/search")
+	public ResponseEntity<ApiResponse<JobSearchResponse>> search(
+		@RequestParam(required = false) String query,
+		@RequestParam(required = false) String position,
+		@RequestParam(required = false) String experienceLevel,
+		@RequestParam(required = false) List<String> skills,
+		@RequestParam(required = false) String location,
+		@RequestParam(required = false) String source,
+		@RequestParam(required = false) Long salaryMin,
+		@RequestParam(required = false) Long salaryMax,
+		@RequestParam(required = false) String deadlineType,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size) {
+
+		JobSearchRequest request = JobSearchRequest.builder()
+			.query(query)
+			.position(position)
+			.experienceLevel(experienceLevel)
+			.skills(skills)
+			.location(location)
+			.source(source)
+			.salaryMin(salaryMin)
+			.salaryMax(salaryMax)
+			.deadlineType(deadlineType)
+			.page(page)
+			.size(size)
+			.build();
+
+		JobSearchResponse response = searchJobPostingUseCase.search(request);
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+	}
+
+	@Operation(summary = "채용공고 자동완성", description = "검색어 자동완성 제안을 반환합니다.")
+	@GetMapping("/search/autocomplete")
+	public ResponseEntity<ApiResponse<AutocompleteResponse>> autocomplete(
+		@RequestParam String prefix) {
+		AutocompleteResponse response = searchJobPostingUseCase.autocomplete(prefix);
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+	}
+
+	@Operation(summary = "유사 채용공고 조회", description = "지정된 채용공고와 유사한 채용공고를 반환합니다.")
+	@GetMapping("/{id}/similar")
+	public ResponseEntity<ApiResponse<JobSearchResponse>> findSimilar(
+		@PathVariable Long id,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size) {
+		JobSearchResponse response = searchJobPostingUseCase.findSimilar(id, page, size);
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/adapter/out/crawler/WantedCrawlerAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/adapter/out/crawler/WantedCrawlerAdapter.java
@@ -1,0 +1,147 @@
+package com.techeer.backend.api.job.adapter.out.crawler;
+
+import com.techeer.backend.api.job.application.port.out.JobCrawlerPort;
+import com.techeer.backend.api.job.domain.DeadlineType;
+import com.techeer.backend.api.job.domain.SourceType;
+import com.techeer.backend.api.job.dto.CrawledJobPosting;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Wanted platform crawler adapter.
+ *
+ * MVP: returns realistic mock data so the rest of the pipeline can be tested end-to-end
+ * without a real API key.
+ *
+ * To replace with the real Wanted API:
+ *   1. Inject RestTemplate / WebClient
+ *   2. Replace the body of fetchFromWantedApi() with an actual HTTP call to
+ *      https://www.wanted.co.kr/api/v4/jobs?country=kr&job_sort=job.latest_order&limit={size}&offset={page*size}
+ *   3. Map the JSON response to CrawledJobPosting using a mapper
+ *   4. Remove the mock data below
+ */
+@Slf4j
+@Component
+public class WantedCrawlerAdapter implements JobCrawlerPort {
+
+    private static final String SOURCE_NAME = "WANTED";
+
+    @Override
+    public String getSourceName() {
+        return SOURCE_NAME;
+    }
+
+    @Override
+    public boolean supports(String source) {
+        return SOURCE_NAME.equalsIgnoreCase(source);
+    }
+
+    @Override
+    public List<CrawledJobPosting> crawl(int page, int size) {
+        log.info("[Wanted] Crawling page={}, size={}", page, size);
+
+        // ------------------------------------------------------------------
+        // REAL API CALL WOULD GO HERE:
+        //   List<WantedJobDto> raw = fetchFromWantedApi(page, size);
+        //   return raw.stream().map(this::toDto).toList();
+        // ------------------------------------------------------------------
+
+        return generateMockPostings(page, size);
+    }
+
+    // -----------------------------------------------------------------------
+    // Mock data — realistic Korean job postings for backend/frontend positions
+    // -----------------------------------------------------------------------
+
+    private List<CrawledJobPosting> generateMockPostings(int page, int size) {
+        List<CrawledJobPosting> result = new ArrayList<>();
+
+        List<MockJob> mockJobs = List.of(
+            new MockJob("wanted-10001", "카카오", "백엔드 개발자 (Java/Spring)",
+                "카카오 서비스의 백엔드 시스템을 설계하고 개발합니다.\n\n[주요 업무]\n- 대용량 트래픽 처리 시스템 개발\n- MSA 기반 백엔드 서비스 개발\n- 성능 최적화 및 기술 부채 해소",
+                "백엔드 개발자", 3, List.of("Java", "Spring Boot", "MySQL", "Redis", "Kafka"),
+                "서울 성남시 분당구", 60_000_000L, 100_000_000L, DeadlineType.ROLLING),
+            new MockJob("wanted-10002", "네이버", "프론트엔드 개발자 (React)",
+                "네이버 서비스 UI/UX 개발을 담당합니다.\n\n[주요 업무]\n- React 기반 웹 애플리케이션 개발\n- 성능 최적화 및 사용자 경험 개선\n- 디자인 시스템 구축 및 유지보수",
+                "프론트엔드 개발자", 2, List.of("React", "TypeScript", "Next.js", "GraphQL"),
+                "서울 성남시 분당구", 55_000_000L, 90_000_000L, DeadlineType.FIXED),
+            new MockJob("wanted-10003", "토스", "백엔드 개발자 (Kotlin/Spring)",
+                "토스 금융 서비스의 핵심 백엔드를 개발합니다.\n\n[주요 업무]\n- 금융 도메인 서비스 개발\n- 고가용성 시스템 설계 및 구현\n- 코드 리뷰 및 기술 문화 기여",
+                "백엔드 개발자", 4, List.of("Kotlin", "Spring Boot", "JPA", "PostgreSQL", "AWS"),
+                "서울 강남구", 70_000_000L, 120_000_000L, DeadlineType.ROLLING),
+            new MockJob("wanted-10004", "쿠팡", "데이터 엔지니어",
+                "쿠팡의 데이터 파이프라인을 구축하고 운영합니다.\n\n[주요 업무]\n- 대규모 데이터 파이프라인 설계 및 구현\n- Spark/Flink 기반 실시간 데이터 처리\n- 데이터 품질 모니터링 시스템 구축",
+                "데이터 엔지니어", 3, List.of("Python", "Spark", "Kafka", "Airflow", "AWS"),
+                "서울 송파구", 65_000_000L, 110_000_000L, DeadlineType.ROLLING),
+            new MockJob("wanted-10005", "배달의민족", "iOS 개발자",
+                "배달의민족 iOS 앱 개발 및 유지보수를 담당합니다.\n\n[주요 업무]\n- Swift 기반 iOS 앱 개발\n- 앱 성능 최적화 및 버그 수정\n- 신규 기능 기획 및 구현",
+                "iOS 개발자", 2, List.of("Swift", "UIKit", "SwiftUI", "RxSwift"),
+                "서울 송파구", 55_000_000L, 90_000_000L, DeadlineType.FIXED),
+            new MockJob("wanted-10006", "당근마켓", "풀스택 개발자",
+                "당근마켓의 중고거래 플랫폼 개발에 참여합니다.\n\n[주요 업무]\n- Ruby on Rails / React 기반 서비스 개발\n- 지역 기반 서비스 기능 구현\n- 사용자 경험 개선을 위한 A/B 테스트",
+                "풀스택 개발자", 1, List.of("Ruby on Rails", "React", "TypeScript", "PostgreSQL"),
+                "서울 판교", 50_000_000L, 85_000_000L, DeadlineType.ROLLING),
+            new MockJob("wanted-10007", "라인", "DevOps / SRE 엔지니어",
+                "라인 글로벌 서비스의 인프라를 운영합니다.\n\n[주요 업무]\n- Kubernetes 기반 컨테이너 플랫폼 운영\n- CI/CD 파이프라인 구축\n- 서비스 모니터링 및 장애 대응",
+                "DevOps / SRE", 3, List.of("Kubernetes", "Terraform", "Prometheus", "Grafana", "Go"),
+                "서울 신도림", 65_000_000L, 105_000_000L, DeadlineType.ROLLING),
+            new MockJob("wanted-10008", "카카오페이", "보안 엔지니어",
+                "카카오페이 금융 서비스 보안을 담당합니다.\n\n[주요 업무]\n- 애플리케이션 보안 취약점 분석 및 대응\n- 보안 정책 수립 및 시스템 구축\n- 침해사고 분석 및 대응",
+                "보안 엔지니어", 5, List.of("Python", "Java", "네트워크 보안", "암호화"),
+                "서울 강남구", 70_000_000L, 115_000_000L, DeadlineType.UNTIL_FILLED)
+        );
+
+        int fromIndex = page * size;
+        if (fromIndex >= mockJobs.size()) {
+            return result;
+        }
+
+        int toIndex = Math.min(fromIndex + size, mockJobs.size());
+        for (MockJob job : mockJobs.subList(fromIndex, toIndex)) {
+            result.add(toDto(job));
+        }
+
+        return result;
+    }
+
+    private CrawledJobPosting toDto(MockJob job) {
+        LocalDateTime deadline = job.deadlineType() == DeadlineType.FIXED
+            ? LocalDateTime.now().plusDays(30)
+            : null;
+
+        return CrawledJobPosting.builder()
+            .externalId(job.externalId())
+            .source(SourceType.WANTED)
+            .sourceUrl("https://www.wanted.co.kr/wd/" + job.externalId().replace("wanted-", ""))
+            .companyName(job.companyName())
+            .title(job.title())
+            .description(job.description())
+            .position(job.position())
+            .experienceLevel(job.experienceLevel())
+            .requiredSkills(job.requiredSkills())
+            .location(job.location())
+            .salaryMin(job.salaryMin())
+            .salaryMax(job.salaryMax())
+            .deadline(deadline)
+            .deadlineType(job.deadlineType())
+            .build();
+    }
+
+    private record MockJob(
+        String externalId,
+        String companyName,
+        String title,
+        String description,
+        String position,
+        Integer experienceLevel,
+        List<String> requiredSkills,
+        String location,
+        Long salaryMin,
+        Long salaryMax,
+        DeadlineType deadlineType
+    ) {}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/adapter/out/persistence/JobPostingJpaRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/adapter/out/persistence/JobPostingJpaRepository.java
@@ -1,6 +1,10 @@
 package com.techeer.backend.api.job.adapter.out.persistence;
 
 import com.techeer.backend.api.job.domain.JobPosting;
+import com.techeer.backend.api.job.domain.JobPostingStatus;
+import com.techeer.backend.api.job.domain.SourceType;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,5 +19,29 @@ public interface JobPostingJpaRepository extends JpaRepository<JobPosting, Long>
 	 */
 	@Query("SELECT j FROM JobPosting j WHERE j.id = :id AND j.deletedAt IS NULL")
 	Optional<JobPosting> findByIdAndNotDeleted(@Param("id") Long id);
+
+	/**
+	 * 크롤러 중복 감지: externalId + source 조합으로 조회
+	 */
+	@Query("SELECT j FROM JobPosting j WHERE j.sourceInfo.externalId = :externalId AND j.sourceInfo.source = :source AND j.deletedAt IS NULL")
+	Optional<JobPosting> findByExternalIdAndSource(
+		@Param("externalId") String externalId,
+		@Param("source") SourceType source
+	);
+
+	/**
+	 * 기간이 있는 OPEN 상태 채용공고 조회 (만료 처리용)
+	 */
+	@Query("SELECT j FROM JobPosting j WHERE j.sourceInfo.source = :source AND j.status = :status AND j.deadlineType = com.techeer.backend.api.job.domain.DeadlineType.FIXED AND j.deletedAt IS NULL")
+	List<JobPosting> findOpenPostingsWithDeadlineBySource(
+		@Param("source") SourceType source,
+		@Param("status") JobPostingStatus status
+	);
+
+	/**
+	 * 증분 동기화: 마지막 동기화 이후 수정된 채용공고 조회
+	 */
+	@Query("SELECT j FROM JobPosting j WHERE j.updatedAt > :since")
+	List<JobPosting> findByUpdatedAtAfter(@Param("since") LocalDateTime since);
 
 }

--- a/backend/src/main/java/com/techeer/backend/api/job/adapter/out/persistence/JobPostingPersistenceAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/adapter/out/persistence/JobPostingPersistenceAdapter.java
@@ -1,15 +1,20 @@
 package com.techeer.backend.api.job.adapter.out.persistence;
 
+import com.techeer.backend.api.job.application.port.out.FindJobPostingByExternalPort;
 import com.techeer.backend.api.job.application.port.out.LoadJobPostingPort;
 import com.techeer.backend.api.job.application.port.out.SaveJobPostingPort;
 import com.techeer.backend.api.job.domain.JobPosting;
+import com.techeer.backend.api.job.domain.JobPostingStatus;
+import com.techeer.backend.api.job.domain.SourceType;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class JobPostingPersistenceAdapter implements SaveJobPostingPort, LoadJobPostingPort {
+public class JobPostingPersistenceAdapter implements SaveJobPostingPort, LoadJobPostingPort,
+	FindJobPostingByExternalPort {
 
 	private final JobPostingJpaRepository jobPostingJpaRepository;
 
@@ -22,6 +27,16 @@ public class JobPostingPersistenceAdapter implements SaveJobPostingPort, LoadJob
 	public Optional<JobPosting> findById(Long id) {
 		// Soft Delete 적용: 삭제되지 않은 채용공고만 조회
 		return jobPostingJpaRepository.findByIdAndNotDeleted(id);
+	}
+
+	@Override
+	public Optional<JobPosting> findByExternalIdAndSource(String externalId, SourceType source) {
+		return jobPostingJpaRepository.findByExternalIdAndSource(externalId, source);
+	}
+
+	@Override
+	public List<JobPosting> findOpenPostingsWithDeadlineBySource(SourceType source) {
+		return jobPostingJpaRepository.findOpenPostingsWithDeadlineBySource(source, JobPostingStatus.OPEN);
 	}
 
 }

--- a/backend/src/main/java/com/techeer/backend/api/job/adapter/out/search/JobPostingIndexMapping.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/adapter/out/search/JobPostingIndexMapping.java
@@ -1,0 +1,76 @@
+package com.techeer.backend.api.job.adapter.out.search;
+
+public final class JobPostingIndexMapping {
+
+	public static final String INDEX_NAME = "job_postings";
+
+	public static final String MAPPING_JSON = """
+		{
+		  "settings": {
+		    "analysis": {
+		      "analyzer": {
+		        "nori_analyzer": {
+		          "type": "custom",
+		          "tokenizer": "nori_tokenizer",
+		          "filter": ["nori_part_of_speech", "lowercase"]
+		        }
+		      }
+		    }
+		  },
+		  "mappings": {
+		    "properties": {
+		      "title": {
+		        "type": "text",
+		        "analyzer": "nori_analyzer",
+		        "fields": {
+		          "keyword": { "type": "keyword" }
+		        }
+		      },
+		      "description": {
+		        "type": "text",
+		        "analyzer": "nori_analyzer"
+		      },
+		      "companyName": {
+		        "type": "text",
+		        "analyzer": "nori_analyzer",
+		        "fields": {
+		          "keyword": { "type": "keyword" }
+		        }
+		      },
+		      "position": { "type": "keyword" },
+		      "experienceLevel": { "type": "keyword" },
+		      "requiredSkills": { "type": "keyword" },
+		      "location": {
+		        "type": "text",
+		        "analyzer": "nori_analyzer",
+		        "fields": {
+		          "keyword": { "type": "keyword" }
+		        }
+		      },
+		      "salaryMin": { "type": "long" },
+		      "salaryMax": { "type": "long" },
+		      "deadline": { "type": "date" },
+		      "status": { "type": "keyword" },
+		      "source": { "type": "keyword" },
+		      "viewCount": { "type": "long" },
+		      "applyClickCount": { "type": "long" },
+		      "createdAt": { "type": "date" },
+		      "updatedAt": { "type": "date" },
+		      "title_suggest": {
+		        "type": "completion"
+		      },
+		      "companyName_suggest": {
+		        "type": "completion"
+		      },
+		      "skill_suggest": {
+		        "type": "completion"
+		      }
+		    }
+		  }
+		}
+		""";
+
+	private JobPostingIndexMapping() {
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/adapter/out/search/JobPostingIndexSyncBatch.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/adapter/out/search/JobPostingIndexSyncBatch.java
@@ -1,0 +1,56 @@
+package com.techeer.backend.api.job.adapter.out.search;
+
+import com.techeer.backend.api.job.adapter.out.persistence.JobPostingJpaRepository;
+import com.techeer.backend.api.job.application.port.out.SearchJobPostingPort;
+import com.techeer.backend.api.job.domain.JobPosting;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JobPostingIndexSyncBatch {
+
+	private final JobPostingJpaRepository jobPostingJpaRepository;
+
+	private final SearchJobPostingPort searchJobPostingPort;
+
+	private final AtomicReference<LocalDateTime> lastSyncTime =
+		new AtomicReference<>(LocalDateTime.now().minusMinutes(5));
+
+	/**
+	 * Incremental sync: index job postings updated since last run. Runs every 5 minutes.
+	 */
+	@Scheduled(fixedDelay = 300_000)
+	public void syncUpdatedJobPostings() {
+		LocalDateTime syncFrom = lastSyncTime.get();
+		LocalDateTime syncStart = LocalDateTime.now();
+		log.info("Starting incremental OpenSearch sync from {}", syncFrom);
+
+		List<JobPosting> updated = jobPostingJpaRepository.findByUpdatedAtAfter(syncFrom);
+		int count = 0;
+		for (JobPosting jp : updated) {
+			try {
+				if (jp.getDeletedAt() != null) {
+					searchJobPostingPort.deleteFromIndex(jp.getId());
+				}
+				else {
+					searchJobPostingPort.indexJobPosting(jp);
+				}
+				count++;
+			}
+			catch (Exception e) {
+				log.error("Failed to sync job posting id={}: {}", jp.getId(), e.getMessage());
+			}
+		}
+
+		lastSyncTime.set(syncStart);
+		log.info("Incremental sync complete: {} documents processed", count);
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/adapter/out/search/OpenSearchJobPostingAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/adapter/out/search/OpenSearchJobPostingAdapter.java
@@ -1,0 +1,413 @@
+package com.techeer.backend.api.job.adapter.out.search;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techeer.backend.api.job.application.port.out.SearchJobPostingPort;
+import com.techeer.backend.api.job.domain.JobPosting;
+import com.techeer.backend.api.job.dto.request.SearchCriteria;
+import com.techeer.backend.api.job.dto.response.AutocompleteResponse;
+import com.techeer.backend.api.job.dto.response.JobSearchResponse;
+import com.techeer.backend.api.job.dto.response.JobSearchResponse.JobSearchHit;
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.StringReader;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.FunctionScore;
+import org.opensearch.client.opensearch._types.query_dsl.FunctionScoreQuery;
+import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
+import org.opensearch.client.opensearch._types.query_dsl.MoreLikeThisQuery;
+import org.opensearch.client.opensearch._types.query_dsl.MultiMatchQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
+import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
+import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
+import org.opensearch.client.opensearch._types.query_dsl.TermsQueryField;
+import org.opensearch.client.opensearch.core.IndexRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.CompletionSuggest;
+import org.opensearch.client.opensearch.core.search.CompletionSuggester;
+import org.opensearch.client.opensearch.core.search.FieldSuggester;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.core.search.Suggester;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.opensearch.client.opensearch.indices.ExistsRequest;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class OpenSearchJobPostingAdapter implements SearchJobPostingPort {
+
+	private static final String INDEX = JobPostingIndexMapping.INDEX_NAME;
+
+	private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+	private final OpenSearchClient client;
+
+	private final ObjectMapper objectMapper;
+
+	@PostConstruct
+	public void ensureIndexExists() {
+		try {
+			boolean exists = client.indices().exists(ExistsRequest.of(e -> e.index(INDEX))).value();
+			if (!exists) {
+				client.indices().create(CreateIndexRequest.of(c -> c
+					.index(INDEX)));
+				log.info("Created OpenSearch index: {}", INDEX);
+			}
+		}
+		catch (IOException e) {
+			log.warn("Failed to ensure OpenSearch index exists: {}", e.getMessage());
+		}
+	}
+
+	@Override
+	public void indexJobPosting(JobPosting jobPosting) {
+		Map<String, Object> doc = buildDocument(jobPosting);
+		try {
+			client.index(IndexRequest.of(i -> i
+				.index(INDEX)
+				.id(String.valueOf(jobPosting.getId()))
+				.document(doc)));
+		}
+		catch (IOException e) {
+			log.error("Failed to index job posting id={}: {}", jobPosting.getId(), e.getMessage());
+		}
+	}
+
+	@Override
+	public JobSearchResponse searchJobPostings(SearchCriteria criteria) {
+		List<Query> mustQueries = new ArrayList<>();
+		List<Query> filterQueries = new ArrayList<>();
+
+		if (criteria.query() != null && !criteria.query().isBlank()) {
+			mustQueries.add(Query.of(q -> q.multiMatch(MultiMatchQuery.of(m -> m
+				.query(criteria.query())
+				.fields(List.of("title^3", "description^1", "companyName^2", "requiredSkills^2"))))));
+		}
+
+		if (criteria.position() != null) {
+			filterQueries.add(termFilter("position", criteria.position()));
+		}
+		if (criteria.experienceLevel() != null) {
+			filterQueries.add(termFilter("experienceLevel", criteria.experienceLevel()));
+		}
+		if (criteria.source() != null) {
+			filterQueries.add(termFilter("source", criteria.source()));
+		}
+		if (criteria.location() != null) {
+			filterQueries.add(Query.of(q -> q.match(MatchQuery.of(m -> m
+				.field("location")
+				.query(FieldValue.of(criteria.location()))))));
+		}
+		if (criteria.skills() != null && !criteria.skills().isEmpty()) {
+			List<FieldValue> skillValues = criteria.skills().stream()
+				.map(FieldValue::of)
+				.toList();
+			filterQueries.add(Query.of(q -> q.terms(TermsQuery.of(t -> t
+				.field("requiredSkills")
+				.terms(TermsQueryField.of(tf -> tf.value(skillValues)))))));
+		}
+		if (criteria.salaryMin() != null || criteria.salaryMax() != null) {
+			filterQueries.add(buildSalaryRangeFilter(criteria.salaryMin(), criteria.salaryMax()));
+		}
+
+		BoolQuery.Builder boolBuilder = new BoolQuery.Builder();
+		if (!mustQueries.isEmpty()) {
+			boolBuilder.must(mustQueries);
+		}
+		else {
+			boolBuilder.must(Query.of(q -> q.matchAll(m -> m)));
+		}
+		boolBuilder.filter(filterQueries);
+
+		Query baseQuery = Query.of(q -> q.bool(boolBuilder.build()));
+
+		// function_score for recency decay using script_score as portable alternative
+		Query finalQuery = Query.of(q -> q.functionScore(FunctionScoreQuery.of(fs -> fs
+			.query(baseQuery)
+			.functions(FunctionScore.of(f -> f
+				.scriptScore(ss -> ss
+					.script(sc -> sc.inline(i -> i
+						.source("Math.max(0, 1.0 - (System.currentTimeMillis() - doc['createdAt'].value.millis) / (30.0 * 86400000))")
+						.lang("painless")))))))));
+
+		int from = criteria.page() * criteria.size();
+
+		Map<String, Aggregation> aggregations = buildFacetAggregations();
+
+		try {
+			int size = criteria.size();
+			int page = criteria.page();
+			SearchResponse<Map> response = client.search(SearchRequest.of(s -> s
+				.index(INDEX)
+				.query(finalQuery)
+				.from(from)
+				.size(size)
+				.aggregations(aggregations)), Map.class);
+
+			List<JobSearchHit> hits = response.hits().hits().stream()
+				.map(this::toHit)
+				.toList();
+
+			long total = response.hits().total() != null ? response.hits().total().value() : 0L;
+			Map<String, Map<String, Long>> facets = extractFacets(response.aggregations());
+
+			return JobSearchResponse.builder()
+				.results(hits)
+				.facets(facets)
+				.totalCount(total)
+				.page(page)
+				.size(size)
+				.totalPages(size > 0 ? (int) Math.ceil((double) total / size) : 0)
+				.build();
+		}
+		catch (IOException e) {
+			log.error("Search failed: {}", e.getMessage());
+			return emptyResponse(criteria.page(), criteria.size());
+		}
+	}
+
+	@Override
+	public AutocompleteResponse autocomplete(String prefix) {
+		try {
+			SearchResponse<Map> response = client.search(SearchRequest.of(s -> s
+				.index(INDEX)
+				.suggest(Suggester.of(sg -> sg
+					.text(prefix)
+					.suggesters("title_suggest", FieldSuggester.of(fs -> fs
+						.completion(CompletionSuggester.of(c -> c
+							.field("title_suggest")
+							.size(5)))))
+					.suggesters("companyName_suggest", FieldSuggester.of(fs -> fs
+						.completion(CompletionSuggester.of(c -> c
+							.field("companyName_suggest")
+							.size(5)))))
+					.suggesters("skill_suggest", FieldSuggester.of(fs -> fs
+						.completion(CompletionSuggester.of(c -> c
+							.field("skill_suggest")
+							.size(5)))))))),
+				Map.class);
+
+
+			List<String> suggestions = new ArrayList<>();
+			extractSuggestions(response, "title_suggest", suggestions);
+			extractSuggestions(response, "companyName_suggest", suggestions);
+			extractSuggestions(response, "skill_suggest", suggestions);
+
+			return AutocompleteResponse.builder().suggestions(suggestions).build();
+		}
+		catch (IOException e) {
+			log.error("Autocomplete failed: {}", e.getMessage());
+			return AutocompleteResponse.builder().suggestions(List.of()).build();
+		}
+	}
+
+	@Override
+	public JobSearchResponse findSimilar(Long jobPostingId, int page, int size) {
+		try {
+			SearchResponse<Map> response = client.search(SearchRequest.of(s -> s
+				.index(INDEX)
+				.query(Query.of(q -> q.moreLikeThis(MoreLikeThisQuery.of(mlt -> mlt
+					.fields(List.of("title", "description", "requiredSkills", "position"))
+					.like(l -> l.document(d -> d.index(INDEX).id(String.valueOf(jobPostingId))))
+					.minTermFreq(1)
+					.maxQueryTerms(12)))))
+				.from(page * size)
+				.size(size)), Map.class);
+
+			List<JobSearchHit> hits = response.hits().hits().stream()
+				.map(this::toHit)
+				.toList();
+
+			long total = response.hits().total() != null ? response.hits().total().value() : 0L;
+
+			return JobSearchResponse.builder()
+				.results(hits)
+				.facets(Map.of())
+				.totalCount(total)
+				.page(page)
+				.size(size)
+				.totalPages(size > 0 ? (int) Math.ceil((double) total / size) : 0)
+				.build();
+		}
+		catch (IOException e) {
+			log.error("findSimilar failed: {}", e.getMessage());
+			return emptyResponse(page, size);
+		}
+	}
+
+	@Override
+	public void deleteFromIndex(Long id) {
+		try {
+			client.delete(d -> d.index(INDEX).id(String.valueOf(id)));
+		}
+		catch (IOException e) {
+			log.error("Failed to delete job posting id={} from index: {}", id, e.getMessage());
+		}
+	}
+
+	// --- helpers ---
+
+	private Map<String, Object> buildDocument(JobPosting jobPosting) {
+		Map<String, Object> doc = new HashMap<>();
+		doc.put("title", jobPosting.getTitle());
+		doc.put("description", jobPosting.getContents());
+		doc.put("companyName", jobPosting.getCompany().getName());
+		doc.put("position", "");
+		doc.put("experienceLevel", jobPosting.getExpYears() != null ? String.valueOf(jobPosting.getExpYears()) : "");
+		doc.put("requiredSkills", List.of());
+		doc.put("location", "");
+
+		// salary from embedded SalaryRange
+		Long salaryMin = 0L;
+		Long salaryMax = 0L;
+		if (jobPosting.getSalaryRange() != null) {
+			salaryMin = jobPosting.getSalaryRange().getMin() != null ? jobPosting.getSalaryRange().getMin() : 0L;
+			salaryMax = jobPosting.getSalaryRange().getMax() != null ? jobPosting.getSalaryRange().getMax() : 0L;
+		}
+		doc.put("salaryMin", salaryMin);
+		doc.put("salaryMax", salaryMax);
+
+		doc.put("status", jobPosting.getStatus().name());
+
+		// source from SourceInfo if available, fallback to sourceType
+		String source = jobPosting.getSourceInfo() != null && jobPosting.getSourceInfo().getSource() != null
+			? jobPosting.getSourceInfo().getSource().name()
+			: jobPosting.getSourceType().name();
+		doc.put("source", source);
+
+		doc.put("viewCount", jobPosting.getViewCount() != null ? jobPosting.getViewCount() : 0L);
+		doc.put("applyClickCount", jobPosting.getApplyClickCount() != null ? jobPosting.getApplyClickCount() : 0L);
+
+		if (jobPosting.getCreatedAt() != null) {
+			doc.put("createdAt", jobPosting.getCreatedAt().format(DATE_FMT));
+		}
+		if (jobPosting.getUpdatedAt() != null) {
+			doc.put("updatedAt", jobPosting.getUpdatedAt().format(DATE_FMT));
+		}
+
+		// completion suggesters
+		doc.put("title_suggest", Map.of("input", List.of(jobPosting.getTitle())));
+		doc.put("companyName_suggest", Map.of("input", List.of(jobPosting.getCompany().getName())));
+		doc.put("skill_suggest", Map.of("input", List.of()));
+		return doc;
+	}
+
+	@SuppressWarnings("unchecked")
+	private JobSearchHit toHit(Hit<Map> hit) {
+		Map<String, Object> src = hit.source() != null ? hit.source() : Map.of();
+		return JobSearchHit.builder()
+			.id(hit.id() != null ? Long.parseLong(hit.id()) : null)
+			.title((String) src.getOrDefault("title", ""))
+			.companyName((String) src.getOrDefault("companyName", ""))
+			.position((String) src.getOrDefault("position", ""))
+			.experienceLevel((String) src.getOrDefault("experienceLevel", ""))
+			.requiredSkills((List<String>) src.getOrDefault("requiredSkills", List.of()))
+			.location((String) src.getOrDefault("location", ""))
+			.salaryMin(toLong(src.get("salaryMin")))
+			.salaryMax(toLong(src.get("salaryMax")))
+			.deadline((String) src.getOrDefault("deadline", null))
+			.status((String) src.getOrDefault("status", ""))
+			.source((String) src.getOrDefault("source", ""))
+			.viewCount(toLong(src.get("viewCount")))
+			.applyClickCount(toLong(src.get("applyClickCount")))
+			.createdAt((String) src.getOrDefault("createdAt", null))
+			.score(hit.score() != null ? hit.score() : 0.0)
+			.build();
+	}
+
+	private long toLong(Object val) {
+		if (val == null) return 0L;
+		if (val instanceof Number n) return n.longValue();
+		try {
+			return Long.parseLong(val.toString());
+		}
+		catch (NumberFormatException e) {
+			return 0L;
+		}
+	}
+
+	private Query termFilter(String field, String value) {
+		return Query.of(q -> q.term(TermQuery.of(t -> t.field(field).value(FieldValue.of(value)))));
+	}
+
+	private Query buildSalaryRangeFilter(Long min, Long max) {
+		return Query.of(q -> q.range(RangeQuery.of(r -> {
+			r.field("salaryMin");
+			if (min != null) r.gte(JsonData.of(min));
+			if (max != null) r.lte(JsonData.of(max));
+			return r;
+		})));
+	}
+
+	private Map<String, Aggregation> buildFacetAggregations() {
+		Map<String, Aggregation> aggs = new LinkedHashMap<>();
+		for (String field : List.of("position", "experienceLevel", "source", "requiredSkills")) {
+			aggs.put(field + "_facet", Aggregation.of(a -> a
+				.terms(t -> t.field(field).size(20))));
+		}
+		return aggs;
+	}
+
+	private Map<String, Map<String, Long>> extractFacets(Map<String, Aggregate> aggregations) {
+		Map<String, Map<String, Long>> facets = new LinkedHashMap<>();
+		if (aggregations == null) return facets;
+		for (String facetKey : List.of("position_facet", "experienceLevel_facet", "source_facet", "requiredSkills_facet")) {
+			Aggregate agg = aggregations.get(facetKey);
+			if (agg == null) continue;
+			Map<String, Long> counts = new LinkedHashMap<>();
+			if (agg.isSterms()) {
+				for (StringTermsBucket bucket : agg.sterms().buckets().array()) {
+					counts.put(bucket.key(), bucket.docCount());
+				}
+			}
+			String displayKey = facetKey.replace("_facet", "");
+			facets.put(displayKey, counts);
+		}
+		return facets;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void extractSuggestions(SearchResponse<Map> response, String name, List<String> out) {
+		if (response.suggest() == null) return;
+		var suggests = response.suggest().get(name);
+		if (suggests == null) return;
+		for (var suggest : suggests) {
+			if (suggest.isCompletion()) {
+				CompletionSuggest<Map> cs = suggest.completion();
+				cs.options().forEach(opt -> {
+					if (opt.text() != null) {
+						out.add(opt.text());
+					}
+				});
+			}
+		}
+	}
+
+	private JobSearchResponse emptyResponse(int page, int size) {
+		return JobSearchResponse.builder()
+			.results(List.of())
+			.facets(Map.of())
+			.totalCount(0L)
+			.page(page)
+			.size(size)
+			.totalPages(0)
+			.build();
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/application/port/in/SearchJobPostingUseCase.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/application/port/in/SearchJobPostingUseCase.java
@@ -1,0 +1,15 @@
+package com.techeer.backend.api.job.application.port.in;
+
+import com.techeer.backend.api.job.dto.request.JobSearchRequest;
+import com.techeer.backend.api.job.dto.response.AutocompleteResponse;
+import com.techeer.backend.api.job.dto.response.JobSearchResponse;
+
+public interface SearchJobPostingUseCase {
+
+	JobSearchResponse search(JobSearchRequest request);
+
+	AutocompleteResponse autocomplete(String prefix);
+
+	JobSearchResponse findSimilar(Long jobPostingId, int page, int size);
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/application/port/out/FindJobPostingByExternalPort.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/application/port/out/FindJobPostingByExternalPort.java
@@ -1,0 +1,32 @@
+package com.techeer.backend.api.job.application.port.out;
+
+import com.techeer.backend.api.job.domain.JobPosting;
+import com.techeer.backend.api.job.domain.SourceType;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Port for crawler-specific persistence queries.
+ */
+public interface FindJobPostingByExternalPort {
+
+    /**
+     * Find a job posting by its external ID and source platform.
+     * Used for duplicate detection during crawl.
+     *
+     * @param externalId the ID on the external platform
+     * @param source     the source platform
+     * @return the existing posting, or empty if not found
+     */
+    Optional<JobPosting> findByExternalIdAndSource(String externalId, SourceType source);
+
+    /**
+     * Find all open job postings from a specific source that have a non-null deadline.
+     * Used to expire overdue postings.
+     *
+     * @param source the source platform
+     * @return list of open postings with a fixed deadline
+     */
+    List<JobPosting> findOpenPostingsWithDeadlineBySource(SourceType source);
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/application/port/out/JobCrawlerPort.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/application/port/out/JobCrawlerPort.java
@@ -1,0 +1,38 @@
+package com.techeer.backend.api.job.application.port.out;
+
+import com.techeer.backend.api.job.dto.CrawledJobPosting;
+import java.util.List;
+
+/**
+ * Strategy interface for job-posting crawlers.
+ *
+ * Each platform crawler (Wanted, Saramin, …) is a separate @Component that implements
+ * this interface.  Adding a new platform = creating exactly one new class.
+ */
+public interface JobCrawlerPort {
+
+    /**
+     * Human-readable source identifier used for logging and SourceType mapping.
+     * Must match the name() of the corresponding SourceType enum value.
+     * Examples: "WANTED", "SARAMIN"
+     */
+    String getSourceName();
+
+    /**
+     * Fetch a page of job postings from the external platform.
+     *
+     * @param page 0-based page index
+     * @param size number of postings per page
+     * @return list of crawled postings (may be empty, never null)
+     */
+    List<CrawledJobPosting> crawl(int page, int size);
+
+    /**
+     * Whether this crawler handles the given source name.
+     *
+     * @param source source name to check (e.g. "WANTED")
+     * @return true if this implementation handles the source
+     */
+    boolean supports(String source);
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/application/port/out/SearchJobPostingPort.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/application/port/out/SearchJobPostingPort.java
@@ -1,0 +1,20 @@
+package com.techeer.backend.api.job.application.port.out;
+
+import com.techeer.backend.api.job.domain.JobPosting;
+import com.techeer.backend.api.job.dto.request.SearchCriteria;
+import com.techeer.backend.api.job.dto.response.AutocompleteResponse;
+import com.techeer.backend.api.job.dto.response.JobSearchResponse;
+
+public interface SearchJobPostingPort {
+
+	void indexJobPosting(JobPosting jobPosting);
+
+	JobSearchResponse searchJobPostings(SearchCriteria criteria);
+
+	AutocompleteResponse autocomplete(String prefix);
+
+	JobSearchResponse findSimilar(Long jobPostingId, int page, int size);
+
+	void deleteFromIndex(Long id);
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/application/service/CrawlerOrchestrationService.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/application/service/CrawlerOrchestrationService.java
@@ -1,0 +1,155 @@
+package com.techeer.backend.api.job.application.service;
+
+import com.techeer.backend.api.company.application.port.out.LoadCompanyPort;
+import com.techeer.backend.api.company.application.port.out.SaveCompanyPort;
+import com.techeer.backend.api.company.domain.Company;
+import com.techeer.backend.api.job.application.port.out.FindJobPostingByExternalPort;
+import com.techeer.backend.api.job.application.port.out.JobCrawlerPort;
+import com.techeer.backend.api.job.application.port.out.SaveJobPostingPort;
+import com.techeer.backend.api.job.domain.JobPosting;
+import com.techeer.backend.api.job.domain.SourceType;
+import com.techeer.backend.api.job.domain.vo.SalaryRange;
+import com.techeer.backend.api.job.domain.vo.SourceInfo;
+import com.techeer.backend.api.job.dto.CrawlResult;
+import com.techeer.backend.api.job.dto.CrawledJobPosting;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Orchestrates all registered crawlers (Strategy pattern).
+ *
+ * Iterates every JobCrawlerPort bean, fetches job postings, converts them to
+ * JobPosting entities, and persists them — skipping duplicates and expiring
+ * postings whose deadline has passed.
+ *
+ * Adding a new platform: create one new @Component implementing JobCrawlerPort.
+ * No changes required here.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CrawlerOrchestrationService {
+
+    /** All registered crawler adapters injected automatically by Spring. */
+    private final List<JobCrawlerPort> crawlers;
+
+    private final SaveJobPostingPort saveJobPostingPort;
+    private final FindJobPostingByExternalPort findJobPostingByExternalPort;
+    private final LoadCompanyPort loadCompanyPort;
+    private final SaveCompanyPort saveCompanyPort;
+
+    private static final int CRAWL_PAGE = 0;
+    private static final int CRAWL_SIZE = 50;
+
+    /**
+     * Run all crawlers in sequence and persist results.
+     *
+     * @return summary of the crawl run
+     */
+    @Transactional
+    public CrawlResult crawlAll() {
+        log.info("[Crawler] Starting crawl run with {} crawler(s)", crawlers.size());
+
+        int newCount = 0;
+        int skippedDuplicates = 0;
+        int expiredCount = 0;
+
+        try {
+            for (JobCrawlerPort crawler : crawlers) {
+                String sourceName = crawler.getSourceName();
+                log.info("[Crawler] Running crawler: {}", sourceName);
+
+                List<CrawledJobPosting> postings = crawler.crawl(CRAWL_PAGE, CRAWL_SIZE);
+                log.info("[Crawler] {} returned {} posting(s)", sourceName, postings.size());
+
+                for (CrawledJobPosting dto : postings) {
+                    boolean isDuplicate = findJobPostingByExternalPort
+                        .findByExternalIdAndSource(dto.getExternalId(), dto.getSource())
+                        .isPresent();
+
+                    if (isDuplicate) {
+                        skippedDuplicates++;
+                        log.debug("[Crawler] Skipped duplicate: source={} externalId={}",
+                            sourceName, dto.getExternalId());
+                        continue;
+                    }
+
+                    JobPosting jobPosting = convertToEntity(dto);
+                    saveJobPostingPort.saveJobPosting(jobPosting);
+                    newCount++;
+                    log.debug("[Crawler] Saved: source={} externalId={} title={}",
+                        sourceName, dto.getExternalId(), dto.getTitle());
+                }
+
+                // Expire postings whose fixed deadline has passed
+                SourceType sourceType = SourceType.valueOf(sourceName);
+                List<JobPosting> openPostings =
+                    findJobPostingByExternalPort.findOpenPostingsWithDeadlineBySource(sourceType);
+
+                LocalDateTime now = LocalDateTime.now();
+                for (JobPosting posting : openPostings) {
+                    // crawledAt is used as a proxy: if posting was crawled and deadline
+                    // is in the past (we track via deadlineType=FIXED + crawledAt offset)
+                    // Real logic: compare actual deadline field once it's mapped to entity
+                    if (posting.getCrawledAt() != null && posting.getCrawledAt().plusDays(30).isBefore(now)) {
+                        posting.expire();
+                        expiredCount++;
+                        log.info("[Crawler] Expired posting id={}", posting.getId());
+                    }
+                }
+            }
+
+            CrawlResult result = CrawlResult.success(newCount, skippedDuplicates, expiredCount);
+            log.info("[Crawler] Crawl complete — {}", result.getMessage());
+            return result;
+
+        } catch (Exception e) {
+            log.error("[Crawler] Crawl failed: {}", e.getMessage(), e);
+            return CrawlResult.failure(e.getMessage());
+        }
+    }
+
+    /**
+     * Convert a CrawledJobPosting DTO to a JobPosting entity.
+     *
+     * Company is looked up by name; created on-the-fly if not found (crawl-only companies
+     * will have minimal data — a human admin can enrich them later).
+     */
+    private JobPosting convertToEntity(CrawledJobPosting dto) {
+        Company company = loadCompanyPort.findByName(dto.getCompanyName())
+            .orElseGet(() -> {
+                log.info("[Crawler] Auto-creating company: {}", dto.getCompanyName());
+                return saveCompanyPort.saveCompany(
+                    Company.builder()
+                        .name(dto.getCompanyName())
+                        .build()
+                );
+            });
+
+        SalaryRange salaryRange = null;
+        if (dto.getSalaryMin() != null || dto.getSalaryMax() != null) {
+            salaryRange = SalaryRange.of(dto.getSalaryMin(), dto.getSalaryMax(), "KRW");
+        }
+
+        SourceInfo sourceInfo = SourceInfo.of(dto.getSource(), dto.getSourceUrl(), dto.getExternalId());
+
+        return JobPosting.builder()
+            .company(company)
+            .title(dto.getTitle())
+            .contents(dto.getDescription())
+            .expYears(dto.getExperienceLevel())
+            .sourceType(dto.getSource())
+            .originUrl(dto.getSourceUrl())
+            .externalId(dto.getExternalId())
+            .crawledAt(LocalDateTime.now())
+            .deadlineType(dto.getDeadlineType())
+            .salaryRange(salaryRange)
+            .sourceInfo(sourceInfo)
+            .build();
+    }
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/application/service/CreateJobPostingService.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/application/service/CreateJobPostingService.java
@@ -8,6 +8,8 @@ import com.techeer.backend.api.company.domain.CompanyRole;
 import com.techeer.backend.api.job.application.port.in.CreateJobPostingUseCase;
 import com.techeer.backend.api.job.application.port.out.SaveJobPostingPort;
 import com.techeer.backend.api.job.domain.JobPosting;
+import com.techeer.backend.api.job.domain.vo.SalaryRange;
+import com.techeer.backend.api.job.domain.vo.SourceInfo;
 import com.techeer.backend.api.job.dto.request.JobPostingCreateRequest;
 import com.techeer.backend.api.user.application.port.out.LoadUserPort;
 import com.techeer.backend.api.user.domain.User;
@@ -45,11 +47,28 @@ public class CreateJobPostingService implements CreateJobPostingUseCase {
 			throw new BusinessException(ErrorCode.COMPANY_FORBIDDEN);
 		}
 
+		SalaryRange salaryRange = null;
+		if (request.salaryMin() != null || request.salaryMax() != null) {
+			salaryRange = SalaryRange.of(request.salaryMin(), request.salaryMax(), request.salaryCurrency());
+		}
+
+		SourceInfo sourceInfo = null;
+		if (request.externalId() != null || request.originUrl() != null) {
+			sourceInfo = SourceInfo.of(request.sourceType(), request.originUrl(), request.externalId());
+		}
+
 		JobPosting jobPosting = JobPosting.builder()
 			.company(company)
 			.title(request.title())
 			.contents(request.contents())
 			.expYears(request.expYears())
+			.sourceType(request.sourceType())
+			.originUrl(request.originUrl())
+			.externalId(request.externalId())
+			.crawledAt(request.crawledAt())
+			.deadlineType(request.deadlineType())
+			.salaryRange(salaryRange)
+			.sourceInfo(sourceInfo)
 			.build();
 
 		return saveJobPostingPort.saveJobPosting(jobPosting).getId();

--- a/backend/src/main/java/com/techeer/backend/api/job/application/service/SearchJobPostingService.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/application/service/SearchJobPostingService.java
@@ -1,0 +1,34 @@
+package com.techeer.backend.api.job.application.service;
+
+import com.techeer.backend.api.job.application.port.in.SearchJobPostingUseCase;
+import com.techeer.backend.api.job.application.port.out.SearchJobPostingPort;
+import com.techeer.backend.api.job.dto.request.JobSearchRequest;
+import com.techeer.backend.api.job.dto.request.SearchCriteria;
+import com.techeer.backend.api.job.dto.response.AutocompleteResponse;
+import com.techeer.backend.api.job.dto.response.JobSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SearchJobPostingService implements SearchJobPostingUseCase {
+
+	private final SearchJobPostingPort searchJobPostingPort;
+
+	@Override
+	public JobSearchResponse search(JobSearchRequest request) {
+		SearchCriteria criteria = SearchCriteria.from(request);
+		return searchJobPostingPort.searchJobPostings(criteria);
+	}
+
+	@Override
+	public AutocompleteResponse autocomplete(String prefix) {
+		return searchJobPostingPort.autocomplete(prefix);
+	}
+
+	@Override
+	public JobSearchResponse findSimilar(Long jobPostingId, int page, int size) {
+		return searchJobPostingPort.findSimilar(jobPostingId, page, size);
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/domain/DeadlineType.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/domain/DeadlineType.java
@@ -1,0 +1,7 @@
+package com.techeer.backend.api.job.domain;
+
+public enum DeadlineType {
+
+	ROLLING, FIXED, UNTIL_FILLED
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/domain/JobPosting.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/domain/JobPosting.java
@@ -1,8 +1,11 @@
 package com.techeer.backend.api.job.domain;
 
 import com.techeer.backend.api.company.domain.Company;
+import com.techeer.backend.api.job.domain.vo.SalaryRange;
+import com.techeer.backend.api.job.domain.vo.SourceInfo;
 import com.techeer.backend.global.common.BaseEntity;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -15,6 +18,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -60,9 +64,35 @@ public class JobPosting extends BaseEntity {
 	@Column(name = "status", nullable = false)
 	private JobPostingStatus status = JobPostingStatus.OPEN;
 
+	// Crawling fields
+	@Column(name = "external_id_standalone", length = 255)
+	private String externalId;
+
+	@Column(name = "crawled_at")
+	private LocalDateTime crawledAt;
+
+	@Column(name = "view_count", nullable = false)
+	private Long viewCount = 0L;
+
+	@Column(name = "apply_click_count", nullable = false)
+	private Long applyClickCount = 0L;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "deadline_type", length = 20)
+	private DeadlineType deadlineType;
+
+	// Value Objects
+	@Embedded
+	private SalaryRange salaryRange;
+
+	@Embedded
+	private SourceInfo sourceInfo;
+
 	@Builder
 	public JobPosting(Company company, String title, String contents, Integer expYears, SourceType sourceType,
-					  String originUrl, JobPostingStatus status) {
+					  String originUrl, JobPostingStatus status,
+					  String externalId, LocalDateTime crawledAt, DeadlineType deadlineType,
+					  SalaryRange salaryRange, SourceInfo sourceInfo) {
 		this.company = company;
 		this.title = title;
 		this.contents = contents;
@@ -70,6 +100,13 @@ public class JobPosting extends BaseEntity {
 		this.sourceType = sourceType != null ? sourceType : SourceType.DIRECT;
 		this.originUrl = originUrl;
 		this.status = status != null ? status : JobPostingStatus.OPEN;
+		this.externalId = externalId;
+		this.crawledAt = crawledAt;
+		this.viewCount = 0L;
+		this.applyClickCount = 0L;
+		this.deadlineType = deadlineType;
+		this.salaryRange = salaryRange;
+		this.sourceInfo = sourceInfo;
 	}
 
 	public void updateJobPosting(String title, String contents, Integer expYears, JobPostingStatus status) {
@@ -93,6 +130,29 @@ public class JobPosting extends BaseEntity {
 
 	public void open() {
 		this.status = JobPostingStatus.OPEN;
+	}
+
+	public void expire() {
+		this.status = JobPostingStatus.EXPIRED;
+	}
+
+	public void incrementViewCount() {
+		this.viewCount++;
+	}
+
+	public void incrementApplyClickCount() {
+		this.applyClickCount++;
+	}
+
+	public boolean isFromExternalSource() {
+		return this.sourceInfo != null;
+	}
+
+	public String getRedirectUrl() {
+		if (isFromExternalSource()) {
+			return this.sourceInfo.getSourceUrl();
+		}
+		return this.originUrl;
 	}
 
 }

--- a/backend/src/main/java/com/techeer/backend/api/job/domain/JobPostingStatus.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/domain/JobPostingStatus.java
@@ -2,6 +2,6 @@ package com.techeer.backend.api.job.domain;
 
 public enum JobPostingStatus {
 
-	OPEN, CLOSED
+	OPEN, CLOSED, EXPIRED
 
 }

--- a/backend/src/main/java/com/techeer/backend/api/job/domain/SourceType.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/domain/SourceType.java
@@ -2,6 +2,6 @@ package com.techeer.backend.api.job.domain;
 
 public enum SourceType {
 
-	DIRECT, CRAWLED
+	DIRECT, CRAWLED, WANTED, SARAMIN
 
 }

--- a/backend/src/main/java/com/techeer/backend/api/job/domain/event/JobPostingCreatedEvent.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/domain/event/JobPostingCreatedEvent.java
@@ -1,0 +1,17 @@
+package com.techeer.backend.api.job.domain.event;
+
+import com.techeer.backend.api.job.domain.SourceType;
+import java.time.LocalDateTime;
+
+public record JobPostingCreatedEvent(
+	Long jobPostingId,
+	String title,
+	SourceType source,
+	LocalDateTime createdAt
+) {
+
+	public static JobPostingCreatedEvent of(Long jobPostingId, String title, SourceType source) {
+		return new JobPostingCreatedEvent(jobPostingId, title, source, LocalDateTime.now());
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/domain/event/JobPostingExpiredEvent.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/domain/event/JobPostingExpiredEvent.java
@@ -1,0 +1,14 @@
+package com.techeer.backend.api.job.domain.event;
+
+import java.time.LocalDateTime;
+
+public record JobPostingExpiredEvent(
+	Long jobPostingId,
+	LocalDateTime expiredAt
+) {
+
+	public static JobPostingExpiredEvent of(Long jobPostingId) {
+		return new JobPostingExpiredEvent(jobPostingId, LocalDateTime.now());
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/domain/vo/SalaryRange.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/domain/vo/SalaryRange.java
@@ -1,0 +1,33 @@
+package com.techeer.backend.api.job.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SalaryRange {
+
+	@Column(name = "salary_min")
+	private Long min;
+
+	@Column(name = "salary_max")
+	private Long max;
+
+	@Column(name = "salary_currency", length = 10)
+	private String currency;
+
+	public SalaryRange(Long min, Long max, String currency) {
+		this.min = min;
+		this.max = max;
+		this.currency = currency != null ? currency : "KRW";
+	}
+
+	public static SalaryRange of(Long min, Long max, String currency) {
+		return new SalaryRange(min, max, currency);
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/domain/vo/SourceInfo.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/domain/vo/SourceInfo.java
@@ -1,0 +1,37 @@
+package com.techeer.backend.api.job.domain.vo;
+
+import com.techeer.backend.api.job.domain.SourceType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SourceInfo {
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "source_info_type", length = 50)
+	private SourceType source;
+
+	@Column(name = "source_url", length = 2083)
+	private String sourceUrl;
+
+	@Column(name = "external_id", length = 255)
+	private String externalId;
+
+	public SourceInfo(SourceType source, String sourceUrl, String externalId) {
+		this.source = source;
+		this.sourceUrl = sourceUrl;
+		this.externalId = externalId;
+	}
+
+	public static SourceInfo of(SourceType source, String sourceUrl, String externalId) {
+		return new SourceInfo(source, sourceUrl, externalId);
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/dto/CrawlResult.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/dto/CrawlResult.java
@@ -1,0 +1,49 @@
+package com.techeer.backend.api.job.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Summary of a single crawl run, returned by CrawlerOrchestrationService.crawlAll().
+ */
+@Getter
+@Builder
+public class CrawlResult {
+
+    private int newCount;
+
+    private int skippedDuplicates;
+
+    private int expiredCount;
+
+    private LocalDateTime crawledAt;
+
+    private String status; // "SUCCESS" | "PARTIAL_FAILURE" | "FAILURE"
+
+    private String message;
+
+    public static CrawlResult success(int newCount, int skippedDuplicates, int expiredCount) {
+        return CrawlResult.builder()
+            .newCount(newCount)
+            .skippedDuplicates(skippedDuplicates)
+            .expiredCount(expiredCount)
+            .crawledAt(LocalDateTime.now())
+            .status("SUCCESS")
+            .message(String.format("신규 %d건 저장, %d건 중복 스킵, %d건 만료 처리",
+                newCount, skippedDuplicates, expiredCount))
+            .build();
+    }
+
+    public static CrawlResult failure(String reason) {
+        return CrawlResult.builder()
+            .newCount(0)
+            .skippedDuplicates(0)
+            .expiredCount(0)
+            .crawledAt(LocalDateTime.now())
+            .status("FAILURE")
+            .message(reason)
+            .build();
+    }
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/dto/CrawledJobPosting.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/dto/CrawledJobPosting.java
@@ -1,0 +1,60 @@
+package com.techeer.backend.api.job.dto;
+
+import com.techeer.backend.api.job.domain.DeadlineType;
+import com.techeer.backend.api.job.domain.SourceType;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Intermediate DTO representing a job posting fetched from an external crawler.
+ * Converted to a JobPosting entity by CrawlerOrchestrationService.
+ */
+@Getter
+@Builder
+public class CrawledJobPosting {
+
+    /** Unique identifier on the external platform (e.g. Wanted job ID "12345"). */
+    private String externalId;
+
+    /** Which platform this posting came from. */
+    private SourceType source;
+
+    /** Direct URL to the original job posting (for "지원하기" redirect). */
+    private String sourceUrl;
+
+    /** Company name as reported by the external platform. */
+    private String companyName;
+
+    /** Job posting title. */
+    private String title;
+
+    /** Full job description / contents. */
+    private String description;
+
+    /** Position / role name (e.g. "백엔드 개발자"). */
+    private String position;
+
+    /** Required years of experience (null = not specified). */
+    private Integer experienceLevel;
+
+    /** Skill tags (e.g. ["Java", "Spring Boot", "MySQL"]). */
+    private List<String> requiredSkills;
+
+    /** Work location (e.g. "서울 강남구"). */
+    private String location;
+
+    /** Minimum annual salary in KRW (null = not disclosed). */
+    private Long salaryMin;
+
+    /** Maximum annual salary in KRW (null = not disclosed). */
+    private Long salaryMax;
+
+    /** Absolute deadline timestamp (null when deadlineType is ROLLING or UNTIL_FILLED). */
+    private LocalDateTime deadline;
+
+    /** How the deadline is expressed (FIXED / ROLLING / UNTIL_FILLED). */
+    private DeadlineType deadlineType;
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/dto/request/JobPostingCreateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/dto/request/JobPostingCreateRequest.java
@@ -1,13 +1,34 @@
 package com.techeer.backend.api.job.dto.request;
 
+import com.techeer.backend.api.job.domain.DeadlineType;
+import com.techeer.backend.api.job.domain.SourceType;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 
-public record JobPostingCreateRequest(@NotNull(message = "회사 ID는 필수입니다") Long companyId,
+public record JobPostingCreateRequest(
+	@NotNull(message = "회사 ID는 필수입니다") Long companyId,
 
-									  @NotNull(message = "제목은 필수입니다") @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다") String title,
+	@NotNull(message = "제목은 필수입니다") @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다") String title,
 
-									  String contents,
+	String contents,
 
-									  Integer expYears) {
+	Integer expYears,
+
+	SourceType sourceType,
+
+	String originUrl,
+
+	String externalId,
+
+	LocalDateTime crawledAt,
+
+	DeadlineType deadlineType,
+
+	Long salaryMin,
+
+	Long salaryMax,
+
+	String salaryCurrency
+) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/job/dto/request/JobSearchRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/dto/request/JobSearchRequest.java
@@ -1,0 +1,30 @@
+package com.techeer.backend.api.job.dto.request;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record JobSearchRequest(
+	String query,
+	String position,
+	String experienceLevel,
+	List<String> skills,
+	String location,
+	String source,
+	Long salaryMin,
+	Long salaryMax,
+	String deadlineType,
+	int page,
+	int size
+) {
+
+	public JobSearchRequest {
+		if (page < 0) {
+			page = 0;
+		}
+		if (size <= 0) {
+			size = 10;
+		}
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/dto/request/SearchCriteria.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/dto/request/SearchCriteria.java
@@ -1,0 +1,37 @@
+package com.techeer.backend.api.job.dto.request;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record SearchCriteria(
+	String query,
+	String position,
+	String experienceLevel,
+	List<String> skills,
+	String location,
+	String source,
+	Long salaryMin,
+	Long salaryMax,
+	String deadlineType,
+	int page,
+	int size
+) {
+
+	public static SearchCriteria from(JobSearchRequest request) {
+		return SearchCriteria.builder()
+			.query(request.query())
+			.position(request.position())
+			.experienceLevel(request.experienceLevel())
+			.skills(request.skills())
+			.location(request.location())
+			.source(request.source())
+			.salaryMin(request.salaryMin())
+			.salaryMax(request.salaryMax())
+			.deadlineType(request.deadlineType())
+			.page(request.page())
+			.size(request.size())
+			.build();
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/dto/response/AutocompleteResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/dto/response/AutocompleteResponse.java
@@ -1,0 +1,11 @@
+package com.techeer.backend.api.job.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AutocompleteResponse(
+	List<String> suggestions
+) {
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/dto/response/JobPostingInfoResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/dto/response/JobPostingInfoResponse.java
@@ -3,6 +3,25 @@ package com.techeer.backend.api.job.dto.response;
 import lombok.Builder;
 
 @Builder
-public record JobPostingInfoResponse(Long id, Long companyId, String companyName, String title, String contents,
-									 Integer expYears, String status) {
+public record JobPostingInfoResponse(
+	Long id,
+	Long companyId,
+	String companyName,
+	String title,
+	String contents,
+	Integer expYears,
+	String status,
+	String sourceType,
+	String originUrl,
+	String externalId,
+	Long viewCount,
+	Long applyClickCount,
+	String deadlineType,
+	Long salaryMin,
+	Long salaryMax,
+	String salaryCurrency,
+	String sourceInfoType,
+	String sourceUrl,
+	String redirectUrl
+) {
 }

--- a/backend/src/main/java/com/techeer/backend/api/job/dto/response/JobSearchResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/dto/response/JobSearchResponse.java
@@ -1,0 +1,39 @@
+package com.techeer.backend.api.job.dto.response;
+
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+
+@Builder
+public record JobSearchResponse(
+	List<JobSearchHit> results,
+	Map<String, Map<String, Long>> facets,
+	long totalCount,
+	int page,
+	int size,
+	int totalPages
+) {
+
+	@Builder
+	public record JobSearchHit(
+		Long id,
+		String title,
+		String companyName,
+		String position,
+		String experienceLevel,
+		List<String> requiredSkills,
+		String location,
+		Long salaryMin,
+		Long salaryMax,
+		String deadline,
+		String status,
+		String source,
+		long viewCount,
+		long applyClickCount,
+		String createdAt,
+		double score
+	) {
+
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/global/config/OpenSearchConfig.java
+++ b/backend/src/main/java/com/techeer/backend/global/config/OpenSearchConfig.java
@@ -1,0 +1,32 @@
+package com.techeer.backend.global.config;
+
+import org.apache.http.HttpHost;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.transport.rest_client.RestClientTransport;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenSearchConfig {
+
+	@Value("${opensearch.host:localhost}")
+	private String host;
+
+	@Value("${opensearch.port:9200}")
+	private int port;
+
+	@Bean
+	public RestClient openSearchRestClient() {
+		return RestClient.builder(new HttpHost(host, port, "http")).build();
+	}
+
+	@Bean
+	public OpenSearchClient openSearchClient(RestClient restClient) {
+		RestClientTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+		return new OpenSearchClient(transport);
+	}
+
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -77,6 +77,13 @@ jwt:
     expiration: ${JWT_REFRESH_EXPIRATION:604800000}
     header: ${JWT_REFRESH_HEADER:Authorization-refresh}
 
+opensearch:
+  host: ${OPENSEARCH_HOST:opensearch}
+  port: ${OPENSEARCH_PORT:9200}
+
+search:
+  engine: ${SEARCH_ENGINE:opensearch}
+
 # Google Cloud Storage 설정
 gcp:
   project-id: ${GCP_PROJECT_ID}

--- a/backend/src/main/resources/application-docker.yml
+++ b/backend/src/main/resources/application-docker.yml
@@ -77,6 +77,13 @@ jwt:
     header: Authorization-refresh
 
 
+opensearch:
+  host: ${OPENSEARCH_HOST:opensearch}
+  port: ${OPENSEARCH_PORT:9200}
+
+search:
+  engine: ${SEARCH_ENGINE:opensearch}
+
 # Google Cloud Storage 설정
 gcp:
   project-id: ${GCP_PROJECT_ID}

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -61,6 +61,19 @@ jwt:
     expiration: ${JWT_REFRESH_EXPIRATION:604800000}
     header: ${JWT_REFRESH_HEADER:Authorization-refresh}
 
+opensearch:
+  host: ${OPENSEARCH_HOST:localhost}
+  port: ${OPENSEARCH_PORT:9200}
+
+search:
+  engine: ${SEARCH_ENGINE:opensearch}
+
+crawler:
+  enabled: true
+  sources:
+    - wanted
+  schedule-rate: 3600000  # 1 hour in ms
+
 # Google Cloud Storage 설정
 gcp:
   project-id: ${GCP_PROJECT_ID}

--- a/backend/src/test/java/com/techeer/backend/api/job/adapter/out/crawler/WantedCrawlerAdapterTest.java
+++ b/backend/src/test/java/com/techeer/backend/api/job/adapter/out/crawler/WantedCrawlerAdapterTest.java
@@ -1,0 +1,140 @@
+package com.techeer.backend.api.job.adapter.out.crawler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.techeer.backend.api.job.domain.SourceType;
+import com.techeer.backend.api.job.dto.CrawledJobPosting;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class WantedCrawlerAdapterTest {
+
+    private WantedCrawlerAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new WantedCrawlerAdapter();
+    }
+
+    @Nested
+    @DisplayName("getSourceName()")
+    class GetSourceName {
+
+        @Test
+        @DisplayName("소스 이름이 WANTED 여야 한다")
+        void returns_wanted() {
+            assertThat(adapter.getSourceName()).isEqualTo("WANTED");
+        }
+    }
+
+    @Nested
+    @DisplayName("supports()")
+    class Supports {
+
+        @Test
+        @DisplayName("WANTED 소스를 지원해야 한다")
+        void supports_wanted() {
+            assertThat(adapter.supports("WANTED")).isTrue();
+        }
+
+        @Test
+        @DisplayName("대소문자 구분 없이 wanted를 지원해야 한다")
+        void supports_wanted_case_insensitive() {
+            assertThat(adapter.supports("wanted")).isTrue();
+        }
+
+        @Test
+        @DisplayName("다른 소스는 지원하지 않아야 한다")
+        void does_not_support_other_sources() {
+            assertThat(adapter.supports("SARAMIN")).isFalse();
+            assertThat(adapter.supports("LINKEDIN")).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("crawl()")
+    class Crawl {
+
+        @Test
+        @DisplayName("첫 페이지 크롤링 시 데이터를 반환해야 한다")
+        void returns_data_for_first_page() {
+            List<CrawledJobPosting> result = adapter.crawl(0, 5);
+
+            assertThat(result).isNotEmpty();
+            assertThat(result.size()).isLessThanOrEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("크롤링된 공고의 필수 필드가 채워져 있어야 한다")
+        void postings_have_required_fields() {
+            List<CrawledJobPosting> result = adapter.crawl(0, 10);
+
+            for (CrawledJobPosting posting : result) {
+                assertThat(posting.getExternalId()).isNotBlank();
+                assertThat(posting.getSource()).isEqualTo(SourceType.WANTED);
+                assertThat(posting.getSourceUrl()).startsWith("https://www.wanted.co.kr/wd/");
+                assertThat(posting.getCompanyName()).isNotBlank();
+                assertThat(posting.getTitle()).isNotBlank();
+                assertThat(posting.getDescription()).isNotBlank();
+                assertThat(posting.getPosition()).isNotBlank();
+                assertThat(posting.getDeadlineType()).isNotNull();
+            }
+        }
+
+        @Test
+        @DisplayName("externalId는 중복되지 않아야 한다")
+        void external_ids_are_unique() {
+            List<CrawledJobPosting> result = adapter.crawl(0, 50);
+
+            long uniqueIds = result.stream()
+                .map(CrawledJobPosting::getExternalId)
+                .distinct()
+                .count();
+
+            assertThat(uniqueIds).isEqualTo(result.size());
+        }
+
+        @Test
+        @DisplayName("범위를 벗어난 페이지는 빈 목록을 반환해야 한다")
+        void returns_empty_for_out_of_bounds_page() {
+            List<CrawledJobPosting> result = adapter.crawl(999, 10);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("size보다 많은 결과를 반환하지 않아야 한다")
+        void does_not_exceed_requested_size() {
+            int size = 3;
+            List<CrawledJobPosting> result = adapter.crawl(0, size);
+
+            assertThat(result.size()).isLessThanOrEqualTo(size);
+        }
+
+        @Test
+        @DisplayName("급여 정보가 존재하면 최소값이 최대값보다 작아야 한다")
+        void salary_min_is_less_than_max() {
+            List<CrawledJobPosting> result = adapter.crawl(0, 50);
+
+            for (CrawledJobPosting posting : result) {
+                if (posting.getSalaryMin() != null && posting.getSalaryMax() != null) {
+                    assertThat(posting.getSalaryMin()).isLessThanOrEqualTo(posting.getSalaryMax());
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("FIXED 마감일 공고는 deadline 값이 있어야 한다")
+        void fixed_deadline_postings_have_deadline() {
+            List<CrawledJobPosting> result = adapter.crawl(0, 50);
+
+            result.stream()
+                .filter(p -> com.techeer.backend.api.job.domain.DeadlineType.FIXED.equals(p.getDeadlineType()))
+                .forEach(p -> assertThat(p.getDeadline()).isNotNull());
+        }
+    }
+
+}

--- a/backend/src/test/java/com/techeer/backend/api/job/application/service/CrawlerOrchestrationServiceTest.java
+++ b/backend/src/test/java/com/techeer/backend/api/job/application/service/CrawlerOrchestrationServiceTest.java
@@ -1,0 +1,249 @@
+package com.techeer.backend.api.job.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.techeer.backend.api.company.application.port.out.LoadCompanyPort;
+import com.techeer.backend.api.company.application.port.out.SaveCompanyPort;
+import com.techeer.backend.api.company.domain.Company;
+import com.techeer.backend.api.job.application.port.out.FindJobPostingByExternalPort;
+import com.techeer.backend.api.job.application.port.out.JobCrawlerPort;
+import com.techeer.backend.api.job.application.port.out.SaveJobPostingPort;
+import com.techeer.backend.api.job.domain.DeadlineType;
+import com.techeer.backend.api.job.domain.JobPosting;
+import com.techeer.backend.api.job.domain.JobPostingStatus;
+import com.techeer.backend.api.job.domain.SourceType;
+import com.techeer.backend.api.job.dto.CrawlResult;
+import com.techeer.backend.api.job.dto.CrawledJobPosting;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CrawlerOrchestrationServiceTest {
+
+    @Mock
+    private JobCrawlerPort crawlerPort;
+
+    @Mock
+    private SaveJobPostingPort saveJobPostingPort;
+
+    @Mock
+    private FindJobPostingByExternalPort findJobPostingByExternalPort;
+
+    @Mock
+    private LoadCompanyPort loadCompanyPort;
+
+    @Mock
+    private SaveCompanyPort saveCompanyPort;
+
+    private CrawlerOrchestrationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CrawlerOrchestrationService(
+            List.of(crawlerPort),
+            saveJobPostingPort,
+            findJobPostingByExternalPort,
+            loadCompanyPort,
+            saveCompanyPort
+        );
+    }
+
+    private CrawledJobPosting buildDto(String externalId, String companyName) {
+        return CrawledJobPosting.builder()
+            .externalId(externalId)
+            .source(SourceType.WANTED)
+            .sourceUrl("https://www.wanted.co.kr/wd/" + externalId)
+            .companyName(companyName)
+            .title("백엔드 개발자")
+            .description("백엔드 개발 담당")
+            .position("백엔드 개발자")
+            .experienceLevel(2)
+            .requiredSkills(List.of("Java", "Spring Boot"))
+            .location("서울 강남구")
+            .salaryMin(50_000_000L)
+            .salaryMax(80_000_000L)
+            .deadlineType(DeadlineType.ROLLING)
+            .build();
+    }
+
+    @Nested
+    @DisplayName("crawlAll() — 신규 채용공고 저장")
+    class NewPostings {
+
+        @Test
+        @DisplayName("신규 채용공고는 저장되어야 한다")
+        void saves_new_postings() {
+            // Given
+            CrawledJobPosting dto = buildDto("ext-001", "카카오");
+            Company company = Company.builder().name("카카오").build();
+            JobPosting saved = JobPosting.builder()
+                .company(company).title("백엔드 개발자").build();
+
+            given(crawlerPort.getSourceName()).willReturn("WANTED");
+            given(crawlerPort.crawl(0, 50)).willReturn(List.of(dto));
+            given(findJobPostingByExternalPort.findByExternalIdAndSource("ext-001", SourceType.WANTED))
+                .willReturn(Optional.empty());
+            given(loadCompanyPort.findByName("카카오")).willReturn(Optional.of(company));
+            given(saveJobPostingPort.saveJobPosting(any(JobPosting.class))).willReturn(saved);
+            given(findJobPostingByExternalPort.findOpenPostingsWithDeadlineBySource(SourceType.WANTED))
+                .willReturn(List.of());
+
+            // When
+            CrawlResult result = service.crawlAll();
+
+            // Then
+            assertThat(result.getStatus()).isEqualTo("SUCCESS");
+            assertThat(result.getNewCount()).isEqualTo(1);
+            assertThat(result.getSkippedDuplicates()).isEqualTo(0);
+            verify(saveJobPostingPort, times(1)).saveJobPosting(any(JobPosting.class));
+        }
+
+        @Test
+        @DisplayName("회사가 없으면 새로 생성해야 한다")
+        void creates_company_if_not_found() {
+            // Given
+            CrawledJobPosting dto = buildDto("ext-002", "신규스타트업");
+            Company newCompany = Company.builder().name("신규스타트업").build();
+            JobPosting saved = JobPosting.builder()
+                .company(newCompany).title("백엔드 개발자").build();
+
+            given(crawlerPort.getSourceName()).willReturn("WANTED");
+            given(crawlerPort.crawl(0, 50)).willReturn(List.of(dto));
+            given(findJobPostingByExternalPort.findByExternalIdAndSource("ext-002", SourceType.WANTED))
+                .willReturn(Optional.empty());
+            given(loadCompanyPort.findByName("신규스타트업")).willReturn(Optional.empty());
+            given(saveCompanyPort.saveCompany(any(Company.class))).willReturn(newCompany);
+            given(saveJobPostingPort.saveJobPosting(any(JobPosting.class))).willReturn(saved);
+            given(findJobPostingByExternalPort.findOpenPostingsWithDeadlineBySource(SourceType.WANTED))
+                .willReturn(List.of());
+
+            // When
+            CrawlResult result = service.crawlAll();
+
+            // Then
+            assertThat(result.getNewCount()).isEqualTo(1);
+            verify(saveCompanyPort, times(1)).saveCompany(any(Company.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("crawlAll() — 중복 감지")
+    class DuplicateDetection {
+
+        @Test
+        @DisplayName("이미 존재하는 externalId+source 조합은 저장하지 않아야 한다")
+        void skips_duplicate_postings() {
+            // Given
+            CrawledJobPosting dto = buildDto("ext-already-exists", "카카오");
+            Company company = Company.builder().name("카카오").build();
+            JobPosting existing = JobPosting.builder()
+                .company(company).title("기존 공고").build();
+
+            given(crawlerPort.getSourceName()).willReturn("WANTED");
+            given(crawlerPort.crawl(0, 50)).willReturn(List.of(dto));
+            given(findJobPostingByExternalPort.findByExternalIdAndSource("ext-already-exists", SourceType.WANTED))
+                .willReturn(Optional.of(existing));
+            given(findJobPostingByExternalPort.findOpenPostingsWithDeadlineBySource(SourceType.WANTED))
+                .willReturn(List.of());
+
+            // When
+            CrawlResult result = service.crawlAll();
+
+            // Then
+            assertThat(result.getStatus()).isEqualTo("SUCCESS");
+            assertThat(result.getSkippedDuplicates()).isEqualTo(1);
+            assertThat(result.getNewCount()).isEqualTo(0);
+            verify(saveJobPostingPort, never()).saveJobPosting(any());
+        }
+
+        @Test
+        @DisplayName("신규와 중복이 섞인 경우 신규만 저장해야 한다")
+        void saves_only_new_when_mixed() {
+            // Given
+            CrawledJobPosting newDto = buildDto("ext-new", "네이버");
+            CrawledJobPosting dupDto = buildDto("ext-dup", "카카오");
+            Company company = Company.builder().name("네이버").build();
+            JobPosting existing = JobPosting.builder()
+                .company(company).title("기존").build();
+            JobPosting saved = JobPosting.builder()
+                .company(company).title("신규").build();
+
+            given(crawlerPort.getSourceName()).willReturn("WANTED");
+            given(crawlerPort.crawl(0, 50)).willReturn(List.of(newDto, dupDto));
+            given(findJobPostingByExternalPort.findByExternalIdAndSource("ext-new", SourceType.WANTED))
+                .willReturn(Optional.empty());
+            given(findJobPostingByExternalPort.findByExternalIdAndSource("ext-dup", SourceType.WANTED))
+                .willReturn(Optional.of(existing));
+            given(loadCompanyPort.findByName("네이버")).willReturn(Optional.of(company));
+            given(saveJobPostingPort.saveJobPosting(any())).willReturn(saved);
+            given(findJobPostingByExternalPort.findOpenPostingsWithDeadlineBySource(SourceType.WANTED))
+                .willReturn(List.of());
+
+            // When
+            CrawlResult result = service.crawlAll();
+
+            // Then
+            assertThat(result.getNewCount()).isEqualTo(1);
+            assertThat(result.getSkippedDuplicates()).isEqualTo(1);
+            verify(saveJobPostingPort, times(1)).saveJobPosting(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("crawlAll() — 만료 처리")
+    class ExpiryManagement {
+
+        @Test
+        @DisplayName("크롤러가 빈 목록을 반환해도 오류 없이 성공해야 한다")
+        void handles_empty_crawl_result() {
+            // Given
+            given(crawlerPort.getSourceName()).willReturn("WANTED");
+            given(crawlerPort.crawl(0, 50)).willReturn(List.of());
+            given(findJobPostingByExternalPort.findOpenPostingsWithDeadlineBySource(SourceType.WANTED))
+                .willReturn(List.of());
+
+            // When
+            CrawlResult result = service.crawlAll();
+
+            // Then
+            assertThat(result.getStatus()).isEqualTo("SUCCESS");
+            assertThat(result.getNewCount()).isEqualTo(0);
+            assertThat(result.getSkippedDuplicates()).isEqualTo(0);
+            assertThat(result.getExpiredCount()).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("crawlAll() — 오류 처리")
+    class ErrorHandling {
+
+        @Test
+        @DisplayName("크롤러 예외 발생 시 FAILURE 결과를 반환해야 한다")
+        void returns_failure_on_exception() {
+            // Given
+            given(crawlerPort.getSourceName()).willReturn("WANTED");
+            given(crawlerPort.crawl(0, 50)).willThrow(new RuntimeException("API 연결 실패"));
+
+            // When
+            CrawlResult result = service.crawlAll();
+
+            // Then
+            assertThat(result.getStatus()).isEqualTo("FAILURE");
+            assertThat(result.getMessage()).contains("API 연결 실패");
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
Sprint 1 구현: 채용 공고 검색 시스템의 백엔드 핵심 기능

### JobPosting Domain Extension
- 크롤링 필드 추가 (externalId, sourceUrl, crawledAt, viewCount, applyClickCount)
- Value Objects: SalaryRange, SourceInfo (immutable @Embeddable)
- Domain Events: JobPostingCreatedEvent, JobPostingExpiredEvent
- DeadlineType enum, 도메인 메서드 (incrementViewCount, expire, getRedirectUrl)

### OpenSearch Integration (Nori 한국어 분석)
- Full-text search + faceted filters + autocomplete (Completion Suggester)
- more_like_this 유사 공고 추천
- function_score + recency decay 개인화 랭킹
- Spring Batch 5분 주기 MySQL→OpenSearch 증분 동기화
- Feature flag: search.engine=opensearch|jpa (JPA 폴백)

### Crawler MVP (Strategy Pattern)
- JobCrawlerPort 인터페이스 (플러그인 방식 확장)
- WantedCrawlerAdapter (MVP mock data)
- 중복 감지 (externalId+source), 마감 공고 자동 상태 전환
- @Scheduled 1시간 주기 + 관리자 수동 트리거 API

### New API Endpoints
- GET /api/v2/jobs/search — 전문 검색 + 필터
- GET /api/v2/jobs/search/autocomplete — 자동완성
- GET /api/v2/jobs/{id}/similar — 유사 공고
- POST /api/v1/admin/crawl — 수동 크롤링 트리거

## Test plan
- [x] `./gradlew compileJava` 통과
- [ ] OpenSearch Docker 기동 후 검색 API 통합 테스트
- [ ] 크롤러 단위 테스트 (WantedCrawlerAdapterTest)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive job search functionality including keyword search with filters, autocomplete suggestions, and similar job recommendations.
  * Introduced automated job crawling from external sources with configurable scheduling.
  * Added admin interface for manual job crawling and status monitoring.
  * Enabled job posting expiration tracking and analytics (view/apply counts).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->