### PR TITLE
feat: BE-2.1 user behavior event logging with Redis real-time counters

### DIFF
--- a/backend/src/main/java/com/techeer/backend/api/job/adapter/in/web/UserEventController.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/adapter/in/web/UserEventController.java
@@ -1,0 +1,66 @@
+package com.techeer.backend.api.job.adapter.in.web;
+
+import com.techeer.backend.api.job.application.service.UserEventService;
+import com.techeer.backend.api.job.domain.EventType;
+import com.techeer.backend.api.job.dto.request.UserEventRequest;
+import com.techeer.backend.api.job.dto.response.PopularJobPostingResponse;
+import com.techeer.backend.api.job.dto.response.UserEventResponse;
+import com.techeer.backend.api.user.service.UserService;
+import com.techeer.backend.global.dto.ApiResponse;
+import com.techeer.backend.global.success.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "UserEvent", description = "사용자 행동 이벤트 API")
+@RestController
+@RequestMapping("/api/v1/events")
+@RequiredArgsConstructor
+public class UserEventController {
+
+    private final UserEventService userEventService;
+
+    private final UserService userService;
+
+    @Operation(summary = "이벤트 기록", description = "사용자의 행동 이벤트를 기록합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<UserEventResponse>> recordEvent(
+        @Valid @RequestBody UserEventRequest request) {
+        Long userId = userService.getLoginUser().getId();
+        UserEventResponse response = userEventService.recordEvent(
+            userId, request.jobPostingId(), request.eventType(), request.metadata());
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.success(SuccessCode.USER_EVENT_RECORD_SUCCESS, response));
+    }
+
+    @Operation(summary = "인기 채용공고 조회", description = "조회수 기준 인기 채용공고를 반환합니다.")
+    @GetMapping("/popular")
+    public ResponseEntity<ApiResponse<List<PopularJobPostingResponse>>> getPopularJobPostings(
+        @RequestParam(defaultValue = "10") int limit) {
+        List<PopularJobPostingResponse> response = userEventService.getPopularJobPostings(limit);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.USER_EVENT_POPULAR_SUCCESS, response));
+    }
+
+    @Operation(summary = "이벤트 히스토리 조회", description = "사용자의 이벤트 히스토리를 조회합니다.")
+    @GetMapping("/history")
+    public ResponseEntity<ApiResponse<Page<UserEventResponse>>> getUserEventHistory(
+        @RequestParam EventType eventType,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "20") int size) {
+        Long userId = userService.getLoginUser().getId();
+        Page<UserEventResponse> response = userEventService.getUserEventHistory(userId, eventType, page, size);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.USER_EVENT_HISTORY_SUCCESS, response));
+    }
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/adapter/out/persistence/UserEventJpaRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/adapter/out/persistence/UserEventJpaRepository.java
@@ -1,0 +1,25 @@
+package com.techeer.backend.api.job.adapter.out.persistence;
+
+import com.techeer.backend.api.job.domain.EventType;
+import com.techeer.backend.api.job.domain.UserEvent;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserEventJpaRepository extends JpaRepository<UserEvent, Long> {
+
+    Page<UserEvent> findByUserIdAndEventType(Long userId, EventType eventType, Pageable pageable);
+
+    /**
+     * 이벤트 타입별 job_posting_id 상위 N개 조회 (이벤트 발생 횟수 기준 내림차순)
+     */
+    @Query("SELECT e FROM UserEvent e WHERE e.eventType = :eventType AND e.jobPostingId IS NOT NULL "
+        + "GROUP BY e.jobPostingId ORDER BY COUNT(e.jobPostingId) DESC")
+    List<UserEvent> findTopJobPostingsByEventType(@Param("eventType") EventType eventType, Pageable pageable);
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/adapter/out/persistence/UserEventPersistenceAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/adapter/out/persistence/UserEventPersistenceAdapter.java
@@ -1,0 +1,35 @@
+package com.techeer.backend.api.job.adapter.out.persistence;
+
+import com.techeer.backend.api.job.application.port.out.LoadUserEventPort;
+import com.techeer.backend.api.job.application.port.out.SaveUserEventPort;
+import com.techeer.backend.api.job.domain.EventType;
+import com.techeer.backend.api.job.domain.UserEvent;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserEventPersistenceAdapter implements SaveUserEventPort, LoadUserEventPort {
+
+    private final UserEventJpaRepository userEventJpaRepository;
+
+    @Override
+    public UserEvent saveUserEvent(UserEvent userEvent) {
+        return userEventJpaRepository.save(userEvent);
+    }
+
+    @Override
+    public Page<UserEvent> findByUserIdAndEventType(Long userId, EventType eventType, Pageable pageable) {
+        return userEventJpaRepository.findByUserIdAndEventType(userId, eventType, pageable);
+    }
+
+    @Override
+    public List<UserEvent> findTopJobPostingsByEventType(EventType eventType, int limit) {
+        return userEventJpaRepository.findTopJobPostingsByEventType(eventType, PageRequest.of(0, limit));
+    }
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/application/port/out/LoadUserEventPort.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/application/port/out/LoadUserEventPort.java
@@ -1,0 +1,15 @@
+package com.techeer.backend.api.job.application.port.out;
+
+import com.techeer.backend.api.job.domain.EventType;
+import com.techeer.backend.api.job.domain.UserEvent;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface LoadUserEventPort {
+
+    Page<UserEvent> findByUserIdAndEventType(Long userId, EventType eventType, Pageable pageable);
+
+    List<UserEvent> findTopJobPostingsByEventType(EventType eventType, int limit);
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/application/port/out/SaveUserEventPort.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/application/port/out/SaveUserEventPort.java
@@ -1,0 +1,9 @@
+package com.techeer.backend.api.job.application.port.out;
+
+import com.techeer.backend.api.job.domain.UserEvent;
+
+public interface SaveUserEventPort {
+
+    UserEvent saveUserEvent(UserEvent userEvent);
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/application/service/UserEventService.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/application/service/UserEventService.java
@@ -1,0 +1,115 @@
+package com.techeer.backend.api.job.application.service;
+
+import com.techeer.backend.api.job.application.port.out.LoadUserEventPort;
+import com.techeer.backend.api.job.application.port.out.SaveUserEventPort;
+import com.techeer.backend.api.job.domain.EventType;
+import com.techeer.backend.api.job.domain.UserEvent;
+import com.techeer.backend.api.job.dto.response.PopularJobPostingResponse;
+import com.techeer.backend.api.job.dto.response.UserEventResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class UserEventService {
+
+    private static final Duration IDEMPOTENCY_TTL = Duration.ofSeconds(5);
+
+    private final SaveUserEventPort saveUserEventPort;
+
+    private final LoadUserEventPort loadUserEventPort;
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public UserEventResponse recordEvent(Long userId, Long jobPostingId, EventType eventType, String metadata) {
+        String idempotencyKey = buildIdempotencyKey(userId, jobPostingId, eventType);
+
+        Boolean isNew = stringRedisTemplate.opsForValue()
+            .setIfAbsent(idempotencyKey, "1", IDEMPOTENCY_TTL);
+
+        if (Boolean.FALSE.equals(isNew)) {
+            log.debug("Duplicate event detected, skipping: key={}", idempotencyKey);
+            return null;
+        }
+
+        UserEvent userEvent = UserEvent.builder()
+            .userId(userId)
+            .jobPostingId(jobPostingId)
+            .eventType(eventType)
+            .metadata(metadata)
+            .build();
+
+        UserEvent saved = saveUserEventPort.saveUserEvent(userEvent);
+
+        incrementRedisCounters(jobPostingId, eventType);
+
+        return UserEventResponse.from(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PopularJobPostingResponse> getPopularJobPostings(int limit) {
+        List<UserEvent> topEvents = loadUserEventPort.findTopJobPostingsByEventType(EventType.VIEW, limit);
+
+        return topEvents.stream()
+            .map(event -> {
+                Long jobPostingId = event.getJobPostingId();
+                Long viewCount = getRedisCount(buildViewCountKey(jobPostingId));
+                Long clickCount = getRedisCount(buildClickCountKey(jobPostingId));
+                return new PopularJobPostingResponse(jobPostingId, viewCount, clickCount);
+            })
+            .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<UserEventResponse> getUserEventHistory(Long userId, EventType eventType, int page, int size) {
+        Page<UserEvent> events = loadUserEventPort.findByUserIdAndEventType(
+            userId, eventType, PageRequest.of(page, size));
+        return events.map(UserEventResponse::from);
+    }
+
+    private void incrementRedisCounters(Long jobPostingId, EventType eventType) {
+        if (jobPostingId == null) {
+            return;
+        }
+        if (EventType.VIEW.equals(eventType)) {
+            stringRedisTemplate.opsForValue().increment(buildViewCountKey(jobPostingId));
+        } else if (EventType.APPLY_CLICK.equals(eventType)) {
+            stringRedisTemplate.opsForValue().increment(buildClickCountKey(jobPostingId));
+        }
+    }
+
+    private Long getRedisCount(String key) {
+        String value = stringRedisTemplate.opsForValue().get(key);
+        if (value == null) {
+            return 0L;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+
+    private String buildIdempotencyKey(Long userId, Long jobPostingId, EventType eventType) {
+        return String.format("event:%s:%s:%s", userId, jobPostingId, eventType.name());
+    }
+
+    private String buildViewCountKey(Long jobPostingId) {
+        return String.format("job:%s:views", jobPostingId);
+    }
+
+    private String buildClickCountKey(Long jobPostingId) {
+        return String.format("job:%s:clicks", jobPostingId);
+    }
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/domain/EventType.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/domain/EventType.java
@@ -1,0 +1,9 @@
+package com.techeer.backend.api.job.domain;
+
+public enum EventType {
+    VIEW,
+    BOOKMARK,
+    APPLY_CLICK,
+    SEARCH,
+    SKIP
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/domain/UserEvent.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/domain/UserEvent.java
@@ -1,0 +1,49 @@
+package com.techeer.backend.api.job.domain;
+
+import com.techeer.backend.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "user_events")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserEvent extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_event_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "job_posting_id")
+    private Long jobPostingId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 20)
+    private EventType eventType;
+
+    @Column(name = "metadata", columnDefinition = "JSON")
+    private String metadata;
+
+    @Builder
+    public UserEvent(Long userId, Long jobPostingId, EventType eventType, String metadata) {
+        this.userId = userId;
+        this.jobPostingId = jobPostingId;
+        this.eventType = eventType;
+        this.metadata = metadata;
+    }
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/dto/request/UserEventRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/dto/request/UserEventRequest.java
@@ -1,0 +1,12 @@
+package com.techeer.backend.api.job.dto.request;
+
+import com.techeer.backend.api.job.domain.EventType;
+import jakarta.validation.constraints.NotNull;
+
+public record UserEventRequest(
+    @NotNull EventType eventType,
+    Long jobPostingId,
+    String metadata
+) {
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/dto/response/PopularJobPostingResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/dto/response/PopularJobPostingResponse.java
@@ -1,0 +1,9 @@
+package com.techeer.backend.api.job.dto.response;
+
+public record PopularJobPostingResponse(
+    Long jobPostingId,
+    Long viewCount,
+    Long clickCount
+) {
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/job/dto/response/UserEventResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/job/dto/response/UserEventResponse.java
@@ -1,0 +1,27 @@
+package com.techeer.backend.api.job.dto.response;
+
+import com.techeer.backend.api.job.domain.EventType;
+import com.techeer.backend.api.job.domain.UserEvent;
+import java.time.LocalDateTime;
+
+public record UserEventResponse(
+    Long id,
+    Long userId,
+    Long jobPostingId,
+    EventType eventType,
+    String metadata,
+    LocalDateTime createdAt
+) {
+
+    public static UserEventResponse from(UserEvent userEvent) {
+        return new UserEventResponse(
+            userEvent.getId(),
+            userEvent.getUserId(),
+            userEvent.getJobPostingId(),
+            userEvent.getEventType(),
+            userEvent.getMetadata(),
+            userEvent.getCreatedAt()
+        );
+    }
+
+}

--- a/backend/src/main/java/com/techeer/backend/global/success/SuccessCode.java
+++ b/backend/src/main/java/com/techeer/backend/global/success/SuccessCode.java
@@ -84,7 +84,12 @@ public enum SuccessCode implements BaseStatus {
 	// File Success
 	FILE_UPLOAD_SUCCESS(HttpStatus.OK, "FILE_200", "파일 업로드가 완료되었습니다."),
 	FILE_DELETE_SUCCESS(HttpStatus.OK, "FILE_200", "파일 삭제가 완료되었습니다."),
-	FILE_DOWNLOAD_SUCCESS(HttpStatus.OK, "FILE_200", "파일 다운로드가 완료되었습니다.");
+	FILE_DOWNLOAD_SUCCESS(HttpStatus.OK, "FILE_200", "파일 다운로드가 완료되었습니다."),
+
+	// UserEvent Success
+	USER_EVENT_RECORD_SUCCESS(HttpStatus.CREATED, "EVENT_201", "이벤트가 기록되었습니다."),
+	USER_EVENT_POPULAR_SUCCESS(HttpStatus.OK, "EVENT_200", "인기 채용공고 조회에 성공했습니다."),
+	USER_EVENT_HISTORY_SUCCESS(HttpStatus.OK, "EVENT_200", "이벤트 히스토리 조회에 성공했습니다.");
 
 	private final HttpStatus httpStatus;
 

--- a/backend/src/test/java/com/techeer/backend/api/job/application/service/UserEventServiceTest.java
+++ b/backend/src/test/java/com/techeer/backend/api/job/application/service/UserEventServiceTest.java
@@ -1,0 +1,200 @@
+package com.techeer.backend.api.job.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.techeer.backend.api.job.application.port.out.LoadUserEventPort;
+import com.techeer.backend.api.job.application.port.out.SaveUserEventPort;
+import com.techeer.backend.api.job.domain.EventType;
+import com.techeer.backend.api.job.domain.UserEvent;
+import com.techeer.backend.api.job.dto.response.PopularJobPostingResponse;
+import com.techeer.backend.api.job.dto.response.UserEventResponse;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class UserEventServiceTest {
+
+    @Mock
+    private SaveUserEventPort saveUserEventPort;
+
+    @Mock
+    private LoadUserEventPort loadUserEventPort;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private UserEventService userEventService;
+
+    @BeforeEach
+    void setUp() {
+        org.mockito.Mockito.lenient().when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        userEventService = new UserEventService(saveUserEventPort, loadUserEventPort, stringRedisTemplate);
+    }
+
+    private UserEvent buildUserEvent(Long id, Long userId, Long jobPostingId, EventType eventType) {
+        UserEvent event = UserEvent.builder()
+            .userId(userId)
+            .jobPostingId(jobPostingId)
+            .eventType(eventType)
+            .metadata(null)
+            .build();
+        return event;
+    }
+
+    @Nested
+    @DisplayName("recordEvent() — 이벤트 기록")
+    class RecordEvent {
+
+        @Test
+        @DisplayName("신규 이벤트는 저장되어야 한다")
+        void saves_new_event() {
+            // Given
+            UserEvent saved = buildUserEvent(1L, 1L, 10L, EventType.VIEW);
+            given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
+            given(saveUserEventPort.saveUserEvent(any(UserEvent.class))).willReturn(saved);
+
+            // When
+            UserEventResponse response = userEventService.recordEvent(1L, 10L, EventType.VIEW, null);
+
+            // Then
+            assertThat(response).isNotNull();
+            assertThat(response.eventType()).isEqualTo(EventType.VIEW);
+            verify(saveUserEventPort, times(1)).saveUserEvent(any(UserEvent.class));
+        }
+
+        @Test
+        @DisplayName("중복 이벤트는 저장하지 않아야 한다 (Redis 멱등성)")
+        void skips_duplicate_event() {
+            // Given
+            given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(false);
+
+            // When
+            UserEventResponse response = userEventService.recordEvent(1L, 10L, EventType.VIEW, null);
+
+            // Then
+            assertThat(response).isNull();
+            verify(saveUserEventPort, never()).saveUserEvent(any());
+        }
+
+        @Test
+        @DisplayName("VIEW 이벤트 시 Redis 조회수 카운터가 증가해야 한다")
+        void increments_view_counter_on_view_event() {
+            // Given
+            UserEvent saved = buildUserEvent(1L, 1L, 10L, EventType.VIEW);
+            given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
+            given(saveUserEventPort.saveUserEvent(any(UserEvent.class))).willReturn(saved);
+
+            // When
+            userEventService.recordEvent(1L, 10L, EventType.VIEW, null);
+
+            // Then
+            verify(valueOperations, times(1)).increment(eq("job:10:views"));
+        }
+
+        @Test
+        @DisplayName("APPLY_CLICK 이벤트 시 Redis 클릭 카운터가 증가해야 한다")
+        void increments_click_counter_on_apply_click_event() {
+            // Given
+            UserEvent saved = buildUserEvent(1L, 1L, 10L, EventType.APPLY_CLICK);
+            given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
+            given(saveUserEventPort.saveUserEvent(any(UserEvent.class))).willReturn(saved);
+
+            // When
+            userEventService.recordEvent(1L, 10L, EventType.APPLY_CLICK, null);
+
+            // Then
+            verify(valueOperations, times(1)).increment(eq("job:10:clicks"));
+        }
+
+        @Test
+        @DisplayName("SEARCH 이벤트는 Redis 카운터를 증가시키지 않아야 한다")
+        void does_not_increment_counter_for_search_event() {
+            // Given
+            UserEvent saved = buildUserEvent(1L, 1L, null, EventType.SEARCH);
+            given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
+            given(saveUserEventPort.saveUserEvent(any(UserEvent.class))).willReturn(saved);
+
+            // When
+            userEventService.recordEvent(1L, null, EventType.SEARCH, "{\"query\":\"java developer\"}");
+
+            // Then
+            verify(valueOperations, never()).increment(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("getPopularJobPostings() — 인기 채용공고 조회")
+    class GetPopularJobPostings {
+
+        @Test
+        @DisplayName("인기 채용공고 목록을 Redis 카운터와 함께 반환해야 한다")
+        void returns_popular_job_postings_with_counters() {
+            // Given
+            UserEvent event1 = buildUserEvent(1L, 1L, 10L, EventType.VIEW);
+            UserEvent event2 = buildUserEvent(2L, 2L, 20L, EventType.VIEW);
+            given(loadUserEventPort.findTopJobPostingsByEventType(eq(EventType.VIEW), eq(5))).willReturn(
+                List.of(event1, event2));
+            given(valueOperations.get("job:10:views")).willReturn("42");
+            given(valueOperations.get("job:10:clicks")).willReturn("5");
+            given(valueOperations.get("job:20:views")).willReturn("30");
+            given(valueOperations.get("job:20:clicks")).willReturn(null);
+
+            // When
+            List<PopularJobPostingResponse> result = userEventService.getPopularJobPostings(5);
+
+            // Then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).jobPostingId()).isEqualTo(10L);
+            assertThat(result.get(0).viewCount()).isEqualTo(42L);
+            assertThat(result.get(0).clickCount()).isEqualTo(5L);
+            assertThat(result.get(1).jobPostingId()).isEqualTo(20L);
+            assertThat(result.get(1).viewCount()).isEqualTo(30L);
+            assertThat(result.get(1).clickCount()).isEqualTo(0L);
+        }
+    }
+
+    @Nested
+    @DisplayName("getUserEventHistory() — 이벤트 히스토리 조회")
+    class GetUserEventHistory {
+
+        @Test
+        @DisplayName("사용자의 이벤트 히스토리를 페이지로 반환해야 한다")
+        void returns_paginated_event_history() {
+            // Given
+            UserEvent event = buildUserEvent(1L, 1L, 10L, EventType.VIEW);
+            Page<UserEvent> page = new PageImpl<>(List.of(event), PageRequest.of(0, 20), 1);
+            given(loadUserEventPort.findByUserIdAndEventType(eq(1L), eq(EventType.VIEW), any())).willReturn(page);
+
+            // When
+            Page<UserEventResponse> result = userEventService.getUserEventHistory(1L, EventType.VIEW, 0, 20);
+
+            // Then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0).eventType()).isEqualTo(EventType.VIEW);
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
- Add `UserEvent` JPA entity and `EventType` enum (VIEW, BOOKMARK, APPLY_CLICK, SEARCH, SKIP)
- Implement hexagonal architecture: `SaveUserEventPort`, `LoadUserEventPort`, `UserEventPersistenceAdapter`, `UserEventJpaRepository`
- `UserEventService` with Redis real-time counters (`job:{id}:views`, `job:{id}:clicks`) and 5-second idempotency TTL (`event:{userId}:{jobPostingId}:{eventType}`)
- REST endpoints: `POST /api/v1/events`, `GET /api/v1/events/popular`, `GET /api/v1/events/history`

## Test plan
- [x] `./gradlew compileJava compileTestJava` passes
- [x] 7 unit tests pass in `UserEventServiceTest` covering: new event save, duplicate detection (Redis idempotency), VIEW counter increment, APPLY_CLICK counter increment, SEARCH no-counter, popular job postings with Redis counts, paginated history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added user activity tracking for job postings, recording interactions such as views, bookmarks, applications, and searches.
  * Introduced a popular job postings feature displaying trending jobs based on user engagement metrics.
  * Added user event history view, allowing users to review their past interactions and activity timeline.
  * Implemented idempotent event recording to prevent duplicate tracking with real-time engagement counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->