### PR TITLE
feat: frontend layout renewal + job listing/detail pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,9 @@ import ProtectedRoute from "./utils/Token";
 import MyInfoPage from "./pages/MyInfoPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AuthCallback from "./pages/AuthCallback";
+import JobListPage from "./pages/JobListPage";
+import JobDetailPage from "./pages/JobDetailPage";
+import JobSearchPage from "./pages/JobSearchPage";
 
 // QueryClient 생성
 const queryClient = new QueryClient();
@@ -23,6 +26,9 @@ export default function App() {
               <Route path="/login" element={<Login />} />
               <Route path="/search" element={<SearchPage />} />
               <Route path="/feedback/:id" element={<ResumeFeedbackPage />} />
+              <Route path="/jobs" element={<JobListPage />} />
+              <Route path="/jobs/search" element={<JobSearchPage />} />
+              <Route path="/jobs/:id" element={<JobDetailPage />} />
               <Route element={<ProtectedRoute />}>
                 <Route path="/upload" element={<Upload />} />
                 <Route path="/myInfo" element={<MyInfoPage />} />

--- a/frontend/src/api/jobApi.ts
+++ b/frontend/src/api/jobApi.ts
@@ -1,0 +1,115 @@
+import { jsonAxios } from "./axios.config.ts";
+import * as Sentry from "@sentry/browser";
+
+export interface JobSearchFilters {
+  position?: string;
+  experience?: string;
+  skills?: string[];
+  source?: string;
+  location?: string;
+}
+
+export interface JobSearchParams {
+  query?: string;
+  filters?: JobSearchFilters;
+  page?: number;
+  size?: number;
+}
+
+export interface JobPosting {
+  id: number;
+  title: string;
+  companyName: string;
+  location: string;
+  experienceLevel: string;
+  position: string;
+  skills: string[];
+  source: string;
+  sourceUrl: string;
+  salary?: string;
+  deadline?: string;
+  description?: string;
+  createdAt: string;
+}
+
+export interface JobSearchResponse {
+  content: JobPosting[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+}
+
+export interface AutocompleteItem {
+  keyword: string;
+  type: string;
+}
+
+export interface EventPayload {
+  jobId: number;
+  eventType: "APPLY_CLICK" | "VIEW" | "BOOKMARK";
+  sourceUrl?: string;
+}
+
+export const searchJobs = async (params: JobSearchParams): Promise<JobSearchResponse> => {
+  try {
+    const queryParams = new URLSearchParams();
+    if (params.query) queryParams.set("q", params.query);
+    if (params.page !== undefined) queryParams.set("page", String(params.page));
+    if (params.size !== undefined) queryParams.set("size", String(params.size));
+    if (params.filters?.position) queryParams.set("position", params.filters.position);
+    if (params.filters?.experience) queryParams.set("experience", params.filters.experience);
+    if (params.filters?.source) queryParams.set("source", params.filters.source);
+    if (params.filters?.location) queryParams.set("location", params.filters.location);
+    if (params.filters?.skills?.length) {
+      params.filters.skills.forEach((s) => queryParams.append("skills", s));
+    }
+
+    const response = await jsonAxios.get(`/api/v2/jobs/search?${queryParams.toString()}`);
+    return response.data;
+  } catch (error) {
+    Sentry.captureException(error);
+    throw error;
+  }
+};
+
+export const getJobDetail = async (id: number): Promise<JobPosting> => {
+  try {
+    const response = await jsonAxios.get(`/api/v1/jobs/${id}`);
+    return response.data;
+  } catch (error) {
+    Sentry.captureException(error);
+    throw error;
+  }
+};
+
+export const getSimilarJobs = async (id: number): Promise<JobPosting[]> => {
+  try {
+    const response = await jsonAxios.get(`/api/v2/jobs/${id}/similar`);
+    return response.data;
+  } catch (error) {
+    Sentry.captureException(error);
+    throw error;
+  }
+};
+
+export const getAutocomplete = async (prefix: string): Promise<AutocompleteItem[]> => {
+  try {
+    const response = await jsonAxios.get(
+      `/api/v2/jobs/search/autocomplete?prefix=${encodeURIComponent(prefix)}`
+    );
+    return response.data;
+  } catch (error) {
+    Sentry.captureException(error);
+    throw error;
+  }
+};
+
+export const recordEvent = async (event: EventPayload): Promise<void> => {
+  try {
+    await jsonAxios.post("/api/v1/events", event);
+  } catch (error) {
+    Sentry.captureException(error);
+    throw error;
+  }
+};

--- a/frontend/src/components/Layout/GlobalLayout.tsx
+++ b/frontend/src/components/Layout/GlobalLayout.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import GlobalNavbar from "../common/GlobalNavbar";
+
+interface GlobalLayoutProps {
+  children: React.ReactNode;
+}
+
+function GlobalLayout({ children }: GlobalLayoutProps): React.ReactElement {
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-50">
+      <GlobalNavbar />
+      <main className="flex-1">{children}</main>
+      <footer className="bg-white border-t border-gray-200 mt-auto">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <div className="flex flex-col md:flex-row justify-between items-start gap-6">
+            <div>
+              <span className="text-xl font-bold text-gray-900">
+                Re<span className="text-blue-600">X</span>ume
+              </span>
+              <p className="mt-2 text-sm text-gray-500 max-w-xs">
+                개발자를 위한 채용공고 및 이력서 플랫폼
+              </p>
+            </div>
+            <div className="flex gap-12 text-sm text-gray-500">
+              <div className="space-y-2">
+                <p className="font-semibold text-gray-700">서비스</p>
+                <p className="hover:text-gray-900 cursor-pointer">채용공고</p>
+                <p className="hover:text-gray-900 cursor-pointer">이력서 업로드</p>
+                <p className="hover:text-gray-900 cursor-pointer">마이페이지</p>
+              </div>
+              <div className="space-y-2">
+                <p className="font-semibold text-gray-700">지원</p>
+                <p className="hover:text-gray-900 cursor-pointer">이용약관</p>
+                <p className="hover:text-gray-900 cursor-pointer">개인정보처리방침</p>
+              </div>
+            </div>
+          </div>
+          <p className="mt-6 text-xs text-gray-400 border-t border-gray-100 pt-4">
+            © 2025 ReXume. All rights reserved.
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+export default GlobalLayout;

--- a/frontend/src/components/common/GlobalNavbar.tsx
+++ b/frontend/src/components/common/GlobalNavbar.tsx
@@ -1,0 +1,249 @@
+import { useState, useEffect, useRef } from "react";
+import { Search, User, Menu, X, ChevronDown } from "lucide-react";
+import { useNavigate, useLocation, Link } from "react-router-dom";
+import useAuthStore from "../../store/authStore";
+import useJobStore from "../../store/jobStore";
+
+const NAV_LINKS = [
+  { label: "채용공고", href: "/jobs" },
+  { label: "이력서", href: "/" },
+  { label: "마이페이지", href: "/myInfo" },
+];
+
+function GlobalNavbar() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { checkAuth, userData, isAuthenticated, logout } = useAuthStore();
+  const { setSearchQuery } = useJobStore();
+
+  const [searchText, setSearchText] = useState("");
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [profileOpen, setProfileOpen] = useState(false);
+  const profileRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    checkAuth();
+  }, [checkAuth]);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (profileRef.current && !profileRef.current.contains(e.target as Node)) {
+        setProfileOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  // Close mobile menu on route change
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [location.pathname]);
+
+  const handleSearch = () => {
+    const q = searchText.trim();
+    if (!q) return;
+    setSearchQuery(q);
+    navigate(`/jobs/search?q=${encodeURIComponent(q)}`);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") handleSearch();
+  };
+
+  const handleLogout = async () => {
+    await logout();
+    setProfileOpen(false);
+    navigate("/");
+  };
+
+  const isActive = (href: string) =>
+    href === "/" ? location.pathname === "/" : location.pathname.startsWith(href);
+
+  return (
+    <header className="bg-white border-b border-gray-200 sticky top-0 z-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-16">
+          {/* Logo */}
+          <Link to="/" className="flex-shrink-0">
+            <span className="text-2xl font-bold text-gray-900">
+              Re<span className="text-blue-600">X</span>ume
+            </span>
+          </Link>
+
+          {/* Desktop nav links */}
+          <nav className="hidden md:flex items-center gap-1 ml-8">
+            {NAV_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                to={link.href}
+                className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                  isActive(link.href)
+                    ? "text-blue-600 bg-blue-50"
+                    : "text-gray-600 hover:text-gray-900 hover:bg-gray-100"
+                }`}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+
+          {/* Search bar */}
+          <div className="hidden md:flex flex-1 max-w-md mx-6 relative">
+            <input
+              type="text"
+              placeholder="직무, 회사, 기술스택 검색"
+              className="w-full pl-4 pr-10 py-2 text-sm rounded-full border border-gray-300 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent focus:bg-white transition"
+              value={searchText}
+              onChange={(e) => setSearchText(e.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+            <button
+              onClick={handleSearch}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-blue-600 transition"
+              aria-label="검색"
+            >
+              <Search className="w-4 h-4" />
+            </button>
+          </div>
+
+          {/* Auth area */}
+          <div className="hidden md:flex items-center gap-3">
+            {isAuthenticated ? (
+              <div className="relative" ref={profileRef}>
+                <button
+                  onClick={() => setProfileOpen((v) => !v)}
+                  className="flex items-center gap-2 px-3 py-2 rounded-full bg-gray-100 hover:bg-gray-200 transition text-sm font-medium text-gray-700"
+                >
+                  <div className="w-7 h-7 rounded-full bg-blue-100 flex items-center justify-center">
+                    <User className="w-4 h-4 text-blue-600" />
+                  </div>
+                  <span className="hidden lg:block">{userData?.username}</span>
+                  <ChevronDown className="w-3 h-3" />
+                </button>
+                {profileOpen && (
+                  <div className="absolute right-0 mt-2 w-44 bg-white border border-gray-200 rounded-xl shadow-lg py-1 z-50">
+                    <Link
+                      to="/myInfo"
+                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                      onClick={() => setProfileOpen(false)}
+                    >
+                      마이페이지
+                    </Link>
+                    <Link
+                      to="/upload"
+                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                      onClick={() => setProfileOpen(false)}
+                    >
+                      이력서 업로드
+                    </Link>
+                    <hr className="my-1 border-gray-100" />
+                    <button
+                      onClick={handleLogout}
+                      className="block w-full text-left px-4 py-2 text-sm text-red-500 hover:bg-gray-50"
+                    >
+                      로그아웃
+                    </button>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <Link
+                to="/login"
+                className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition"
+              >
+                로그인
+              </Link>
+            )}
+          </div>
+
+          {/* Mobile hamburger */}
+          <button
+            className="md:hidden p-2 rounded-md text-gray-500 hover:bg-gray-100 transition"
+            onClick={() => setMobileOpen((v) => !v)}
+            aria-label="메뉴"
+          >
+            {mobileOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile menu */}
+      {mobileOpen && (
+        <div className="md:hidden border-t border-gray-100 bg-white">
+          {/* Mobile search */}
+          <div className="px-4 py-3">
+            <div className="relative">
+              <input
+                type="text"
+                placeholder="직무, 회사, 기술스택 검색"
+                className="w-full pl-4 pr-10 py-2 text-sm rounded-full border border-gray-300 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                value={searchText}
+                onChange={(e) => setSearchText(e.target.value)}
+                onKeyDown={handleKeyDown}
+              />
+              <button
+                onClick={handleSearch}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400"
+              >
+                <Search className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+          {/* Mobile nav links */}
+          <nav className="px-4 pb-3 space-y-1">
+            {NAV_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                to={link.href}
+                className={`block px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  isActive(link.href)
+                    ? "text-blue-600 bg-blue-50"
+                    : "text-gray-700 hover:bg-gray-100"
+                }`}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+          {/* Mobile auth */}
+          <div className="px-4 pb-4">
+            {isAuthenticated ? (
+              <div className="space-y-1">
+                <p className="text-xs text-gray-400 px-4 pb-1">{userData?.username}</p>
+                <Link
+                  to="/myInfo"
+                  className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg"
+                >
+                  마이페이지
+                </Link>
+                <Link
+                  to="/upload"
+                  className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg"
+                >
+                  이력서 업로드
+                </Link>
+                <button
+                  onClick={handleLogout}
+                  className="block w-full text-left px-4 py-2 text-sm text-red-500 hover:bg-gray-50 rounded-lg"
+                >
+                  로그아웃
+                </button>
+              </div>
+            ) : (
+              <Link
+                to="/login"
+                className="block w-full text-center px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition"
+              >
+                로그인
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}
+
+export default GlobalNavbar;

--- a/frontend/src/pages/JobDetailPage.tsx
+++ b/frontend/src/pages/JobDetailPage.tsx
@@ -1,0 +1,271 @@
+import { useState } from "react";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  MapPin,
+  Briefcase,
+  Clock,
+  ExternalLink,
+  Bookmark,
+  BookmarkCheck,
+  ArrowLeft,
+  Building2,
+  DollarSign,
+} from "lucide-react";
+import GlobalLayout from "../components/Layout/GlobalLayout";
+import { getJobDetail, getSimilarJobs, recordEvent } from "../api/jobApi";
+
+const SOURCE_COLORS: Record<string, string> = {
+  원티드: "bg-blue-100 text-blue-700",
+  사람인: "bg-green-100 text-green-700",
+  잡코리아: "bg-orange-100 text-orange-700",
+  링크드인: "bg-sky-100 text-sky-700",
+  default: "bg-gray-100 text-gray-600",
+};
+
+function SourceBadge({ source }: { source: string }) {
+  const cls = SOURCE_COLORS[source] ?? SOURCE_COLORS.default;
+  return (
+    <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${cls}`}>
+      {source}
+    </span>
+  );
+}
+
+function JobDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const jobId = Number(id);
+  const [bookmarked, setBookmarked] = useState(false);
+
+  const {
+    data: job,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ["job", jobId],
+    queryFn: () => getJobDetail(jobId),
+    enabled: !!jobId,
+  });
+
+  const { data: similarJobs } = useQuery({
+    queryKey: ["similarJobs", jobId],
+    queryFn: () => getSimilarJobs(jobId),
+    enabled: !!jobId,
+  });
+
+  const handleApply = async () => {
+    if (!job) return;
+    try {
+      await recordEvent({ jobId, eventType: "APPLY_CLICK", sourceUrl: job.sourceUrl });
+    } catch {
+      // non-blocking: proceed even if event recording fails
+    }
+    window.open(job.sourceUrl, "_blank", "noopener,noreferrer");
+  };
+
+  const handleBookmark = async () => {
+    if (!job) return;
+    try {
+      await recordEvent({ jobId, eventType: "BOOKMARK" });
+    } catch {
+      // non-blocking
+    }
+    setBookmarked((v) => !v);
+  };
+
+  if (isLoading) {
+    return (
+      <GlobalLayout>
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-10 animate-pulse">
+          <div className="h-6 bg-gray-200 rounded w-1/4 mb-6" />
+          <div className="bg-white rounded-2xl p-8 border border-gray-200">
+            <div className="h-8 bg-gray-200 rounded w-2/3 mb-4" />
+            <div className="h-4 bg-gray-200 rounded w-1/3 mb-8" />
+            <div className="space-y-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="h-4 bg-gray-100 rounded" />
+              ))}
+            </div>
+          </div>
+        </div>
+      </GlobalLayout>
+    );
+  }
+
+  if (isError || !job) {
+    return (
+      <GlobalLayout>
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16 text-center">
+          <p className="text-lg text-gray-500 mb-4">채용공고를 불러오는 데 실패했습니다.</p>
+          <button
+            onClick={() => navigate(-1)}
+            className="text-blue-600 hover:underline text-sm"
+          >
+            뒤로 가기
+          </button>
+        </div>
+      </GlobalLayout>
+    );
+  }
+
+  return (
+    <GlobalLayout>
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Breadcrumb */}
+        <button
+          onClick={() => navigate(-1)}
+          className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 mb-6 transition"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          채용공고 목록
+        </button>
+
+        {/* Main card */}
+        <div className="bg-white border border-gray-200 rounded-2xl p-8 mb-6">
+          {/* Header */}
+          <div className="flex items-start justify-between gap-4 mb-6">
+            <div className="flex-1">
+              <div className="flex items-center gap-2 mb-2">
+                <SourceBadge source={job.source} />
+                {job.position && (
+                  <span className="px-3 py-1 bg-gray-100 text-gray-600 rounded-full text-sm">
+                    {job.position}
+                  </span>
+                )}
+              </div>
+              <h1 className="text-2xl font-bold text-gray-900 mb-1">{job.title}</h1>
+              <div className="flex items-center gap-1 text-gray-600">
+                <Building2 className="w-4 h-4" />
+                <span className="font-medium">{job.companyName}</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Meta info */}
+          <div className="flex flex-wrap gap-4 text-sm text-gray-500 mb-6 pb-6 border-b border-gray-100">
+            {job.location && (
+              <span className="flex items-center gap-1.5">
+                <MapPin className="w-4 h-4 text-gray-400" />
+                {job.location}
+              </span>
+            )}
+            {job.experienceLevel && (
+              <span className="flex items-center gap-1.5">
+                <Briefcase className="w-4 h-4 text-gray-400" />
+                {job.experienceLevel}
+              </span>
+            )}
+            {job.salary && (
+              <span className="flex items-center gap-1.5">
+                <DollarSign className="w-4 h-4 text-gray-400" />
+                {job.salary}
+              </span>
+            )}
+            {job.deadline && (
+              <span className="flex items-center gap-1.5">
+                <Clock className="w-4 h-4 text-gray-400" />
+                마감일: {job.deadline}
+              </span>
+            )}
+          </div>
+
+          {/* Skills */}
+          {job.skills.length > 0 && (
+            <div className="mb-6">
+              <h2 className="text-sm font-semibold text-gray-700 mb-3">기술 스택</h2>
+              <div className="flex flex-wrap gap-2">
+                {job.skills.map((skill) => (
+                  <span
+                    key={skill}
+                    className="px-3 py-1 bg-blue-50 text-blue-700 rounded-lg text-sm font-medium"
+                  >
+                    {skill}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Description */}
+          {job.description && (
+            <div className="mb-8">
+              <h2 className="text-sm font-semibold text-gray-700 mb-3">공고 내용</h2>
+              <div className="prose prose-sm max-w-none text-gray-700 leading-relaxed whitespace-pre-wrap">
+                {job.description}
+              </div>
+            </div>
+          )}
+
+          {/* Action buttons */}
+          <div className="flex items-center gap-3 pt-4 border-t border-gray-100">
+            <button
+              onClick={handleApply}
+              className="flex-1 sm:flex-none flex items-center justify-center gap-2 px-8 py-3 bg-blue-600 text-white font-semibold rounded-xl hover:bg-blue-700 active:bg-blue-800 transition"
+            >
+              <ExternalLink className="w-4 h-4" />
+              지원하기
+            </button>
+            <button
+              onClick={handleBookmark}
+              className={`flex items-center justify-center gap-2 px-5 py-3 rounded-xl border font-medium transition ${
+                bookmarked
+                  ? "bg-yellow-50 border-yellow-400 text-yellow-600 hover:bg-yellow-100"
+                  : "bg-white border-gray-300 text-gray-600 hover:bg-gray-50"
+              }`}
+              aria-label="북마크"
+            >
+              {bookmarked ? (
+                <BookmarkCheck className="w-5 h-5" />
+              ) : (
+                <Bookmark className="w-5 h-5" />
+              )}
+              <span className="hidden sm:inline">북마크</span>
+            </button>
+          </div>
+        </div>
+
+        {/* Similar jobs */}
+        {similarJobs && similarJobs.length > 0 && (
+          <section>
+            <h2 className="text-base font-bold text-gray-800 mb-4">유사한 채용공고</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {similarJobs.slice(0, 4).map((similar) => (
+                <Link
+                  key={similar.id}
+                  to={`/jobs/${similar.id}`}
+                  className="bg-white border border-gray-200 rounded-xl p-4 hover:shadow-md hover:border-blue-300 transition-all"
+                >
+                  <div className="flex items-start justify-between gap-2 mb-2">
+                    <div>
+                      <p className="text-xs text-gray-500 mb-0.5">{similar.companyName}</p>
+                      <p className="text-sm font-semibold text-gray-900 line-clamp-2">
+                        {similar.title}
+                      </p>
+                    </div>
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0 ${
+                        SOURCE_COLORS[similar.source] ?? SOURCE_COLORS.default
+                      }`}
+                    >
+                      {similar.source}
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {similar.skills.slice(0, 3).map((s) => (
+                      <span key={s} className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded text-xs">
+                        {s}
+                      </span>
+                    ))}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </GlobalLayout>
+  );
+}
+
+export default JobDetailPage;

--- a/frontend/src/pages/JobListPage.tsx
+++ b/frontend/src/pages/JobListPage.tsx
@@ -1,0 +1,318 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { Briefcase, MapPin, Clock, ChevronDown, ChevronUp, SlidersHorizontal, X } from "lucide-react";
+import GlobalLayout from "../components/Layout/GlobalLayout";
+import { searchJobs, JobPosting, JobSearchFilters } from "../api/jobApi";
+import useJobStore from "../store/jobStore";
+
+const SOURCE_COLORS: Record<string, string> = {
+  원티드: "bg-blue-100 text-blue-700",
+  사람인: "bg-green-100 text-green-700",
+  잡코리아: "bg-orange-100 text-orange-700",
+  링크드인: "bg-sky-100 text-sky-700",
+  default: "bg-gray-100 text-gray-600",
+};
+
+const POSITIONS = ["프론트엔드", "백엔드", "풀스택", "데브옵스", "데이터엔지니어", "ML엔지니어", "iOS", "Android"];
+const EXPERIENCES = ["신입", "1~3년", "3~5년", "5년 이상"];
+const LOCATIONS = ["서울", "경기", "인천", "부산", "대구", "원격"];
+const SOURCES = ["원티드", "사람인", "잡코리아", "링크드인"];
+
+interface FilterSectionProps {
+  title: string;
+  options: string[];
+  selected: string | undefined;
+  onSelect: (value: string | undefined) => void;
+}
+
+function FilterSection({ title, options, selected, onSelect }: FilterSectionProps) {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="border-b border-gray-100 pb-4 mb-4">
+      <button
+        className="flex items-center justify-between w-full text-sm font-semibold text-gray-700 mb-3"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {title}
+        {open ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+      </button>
+      {open && (
+        <div className="flex flex-wrap gap-2">
+          {options.map((opt) => (
+            <button
+              key={opt}
+              onClick={() => onSelect(selected === opt ? undefined : opt)}
+              className={`px-3 py-1 rounded-full text-xs font-medium border transition ${
+                selected === opt
+                  ? "bg-blue-600 text-white border-blue-600"
+                  : "bg-white text-gray-600 border-gray-300 hover:border-blue-400 hover:text-blue-600"
+              }`}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SourceBadge({ source }: { source: string }) {
+  const cls = SOURCE_COLORS[source] ?? SOURCE_COLORS.default;
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${cls}`}>
+      {source}
+    </span>
+  );
+}
+
+function JobCard({ job, onClick }: { job: JobPosting; onClick: () => void }) {
+  return (
+    <div
+      onClick={onClick}
+      className="bg-white border border-gray-200 rounded-xl p-5 cursor-pointer hover:shadow-md hover:border-blue-300 transition-all group"
+    >
+      <div className="flex items-start justify-between gap-2 mb-3">
+        <div>
+          <p className="text-xs text-gray-500 mb-1">{job.companyName}</p>
+          <h3 className="text-sm font-semibold text-gray-900 group-hover:text-blue-600 transition line-clamp-2">
+            {job.title}
+          </h3>
+        </div>
+        <SourceBadge source={job.source} />
+      </div>
+      <div className="flex flex-wrap gap-1 mb-3">
+        {job.skills.slice(0, 4).map((skill) => (
+          <span key={skill} className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded text-xs">
+            {skill}
+          </span>
+        ))}
+        {job.skills.length > 4 && (
+          <span className="px-2 py-0.5 bg-gray-100 text-gray-400 rounded text-xs">
+            +{job.skills.length - 4}
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-3 text-xs text-gray-400">
+        {job.location && (
+          <span className="flex items-center gap-1">
+            <MapPin className="w-3 h-3" />
+            {job.location}
+          </span>
+        )}
+        {job.experienceLevel && (
+          <span className="flex items-center gap-1">
+            <Briefcase className="w-3 h-3" />
+            {job.experienceLevel}
+          </span>
+        )}
+        {job.deadline && (
+          <span className="flex items-center gap-1 ml-auto">
+            <Clock className="w-3 h-3" />
+            {job.deadline}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function JobListPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const queryFromUrl = searchParams.get("q") ?? "";
+  const { filters, setFilter, resetFilters } = useJobStore();
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+
+  const activeFiltersCount = Object.values(filters).filter(
+    (v) => v !== undefined && (Array.isArray(v) ? v.length > 0 : true)
+  ).length;
+
+  const fetchPage = useCallback(
+    async ({ pageParam = 0 }) => {
+      return searchJobs({ query: queryFromUrl, filters, page: pageParam, size: 12 });
+    },
+    [queryFromUrl, filters]
+  );
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
+    useInfiniteQuery({
+      queryKey: ["jobs", queryFromUrl, filters],
+      queryFn: fetchPage,
+      getNextPageParam: (lastPage) => {
+        if (lastPage.number + 1 < lastPage.totalPages) return lastPage.number + 1;
+        return undefined;
+      },
+      initialPageParam: 0,
+    });
+
+  // Infinite scroll
+  useEffect(() => {
+    if (!hasNextPage || isFetchingNextPage) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) fetchNextPage();
+      },
+      { threshold: 0.1 }
+    );
+    const el = loadMoreRef.current;
+    if (el) observer.observe(el);
+    return () => {
+      if (el) observer.unobserve(el);
+    };
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const allJobs = data?.pages.flatMap((p) => p.content) ?? [];
+
+  const sidebarContent = (
+    <aside className="w-full">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-bold text-gray-800">필터</h2>
+        {activeFiltersCount > 0 && (
+          <button
+            onClick={resetFilters}
+            className="text-xs text-blue-600 hover:underline flex items-center gap-1"
+          >
+            <X className="w-3 h-3" /> 초기화
+          </button>
+        )}
+      </div>
+      <FilterSection
+        title="포지션"
+        options={POSITIONS}
+        selected={filters.position}
+        onSelect={(v) => setFilter("position", v)}
+      />
+      <FilterSection
+        title="경력"
+        options={EXPERIENCES}
+        selected={filters.experience}
+        onSelect={(v) => setFilter("experience", v)}
+      />
+      <FilterSection
+        title="지역"
+        options={LOCATIONS}
+        selected={filters.location}
+        onSelect={(v) => setFilter("location", v)}
+      />
+      <FilterSection
+        title="출처"
+        options={SOURCES}
+        selected={filters.source}
+        onSelect={(v) => setFilter("source", v)}
+      />
+    </aside>
+  );
+
+  return (
+    <GlobalLayout>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Page header */}
+        <div className="mb-6 flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold text-gray-900">
+              {queryFromUrl ? `"${queryFromUrl}" 검색 결과` : "채용공고"}
+            </h1>
+            {data && (
+              <p className="text-sm text-gray-500 mt-1">
+                총 {data.pages[0]?.totalElements ?? 0}개의 공고
+              </p>
+            )}
+          </div>
+          {/* Mobile filter toggle */}
+          <button
+            className="md:hidden flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-50 transition"
+            onClick={() => setMobileSidebarOpen((v) => !v)}
+          >
+            <SlidersHorizontal className="w-4 h-4" />
+            필터
+            {activeFiltersCount > 0 && (
+              <span className="bg-blue-600 text-white rounded-full text-xs w-5 h-5 flex items-center justify-center">
+                {activeFiltersCount}
+              </span>
+            )}
+          </button>
+        </div>
+
+        <div className="flex gap-6">
+          {/* Desktop sidebar */}
+          <div className="hidden md:block w-56 flex-shrink-0">{sidebarContent}</div>
+
+          {/* Mobile sidebar overlay */}
+          {mobileSidebarOpen && (
+            <div className="fixed inset-0 z-40 md:hidden">
+              <div
+                className="absolute inset-0 bg-black/40"
+                onClick={() => setMobileSidebarOpen(false)}
+              />
+              <div className="absolute left-0 top-0 h-full w-72 bg-white shadow-xl p-5 overflow-y-auto">
+                <button
+                  onClick={() => setMobileSidebarOpen(false)}
+                  className="mb-4 text-gray-500 hover:text-gray-700"
+                >
+                  <X className="w-5 h-5" />
+                </button>
+                {sidebarContent}
+              </div>
+            </div>
+          )}
+
+          {/* Main content */}
+          <div className="flex-1 min-w-0">
+            {isLoading && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {Array.from({ length: 9 }).map((_, i) => (
+                  <div key={i} className="bg-white border border-gray-200 rounded-xl p-5 animate-pulse">
+                    <div className="h-3 bg-gray-200 rounded mb-2 w-1/3" />
+                    <div className="h-4 bg-gray-200 rounded mb-4 w-3/4" />
+                    <div className="flex gap-2 mb-4">
+                      <div className="h-5 bg-gray-200 rounded-full w-16" />
+                      <div className="h-5 bg-gray-200 rounded-full w-16" />
+                    </div>
+                    <div className="h-3 bg-gray-100 rounded w-1/2" />
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {isError && (
+              <div className="text-center py-16 text-gray-500">
+                <p className="text-lg mb-2">채용공고를 불러오는 데 실패했습니다.</p>
+                <p className="text-sm">잠시 후 다시 시도해 주세요.</p>
+              </div>
+            )}
+
+            {!isLoading && !isError && allJobs.length === 0 && (
+              <div className="text-center py-16 text-gray-500">
+                <Briefcase className="w-12 h-12 text-gray-300 mx-auto mb-4" />
+                <p className="text-lg mb-2">검색 결과가 없습니다.</p>
+                <p className="text-sm">다른 키워드나 필터로 검색해 보세요.</p>
+              </div>
+            )}
+
+            {!isLoading && allJobs.length > 0 && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {allJobs.map((job) => (
+                  <JobCard
+                    key={job.id}
+                    job={job}
+                    onClick={() => navigate(`/jobs/${job.id}`)}
+                  />
+                ))}
+              </div>
+            )}
+
+            <div ref={loadMoreRef} className="h-4 mt-4" />
+            {isFetchingNextPage && (
+              <div className="text-center py-4 text-sm text-gray-400">불러오는 중...</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </GlobalLayout>
+  );
+}
+
+export default JobListPage;

--- a/frontend/src/pages/JobSearchPage.tsx
+++ b/frontend/src/pages/JobSearchPage.tsx
@@ -1,0 +1,12 @@
+import { useSearchParams } from "react-router-dom";
+import JobListPage from "./JobListPage";
+
+// JobSearchPage is an alias of JobListPage — the query param `q` is read inside JobListPage.
+function JobSearchPage() {
+  const [searchParams] = useSearchParams();
+  const q = searchParams.get("q");
+  // JobListPage already handles /jobs/search?q=... by reading searchParams
+  return <JobListPage key={q ?? ""} />;
+}
+
+export default JobSearchPage;

--- a/frontend/src/store/jobStore.ts
+++ b/frontend/src/store/jobStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+import { JobSearchFilters } from "../api/jobApi";
+
+interface JobStore {
+  searchQuery: string;
+  filters: JobSearchFilters;
+  setSearchQuery: (query: string) => void;
+  setFilter: (key: keyof JobSearchFilters, value: string | string[] | undefined) => void;
+  resetFilters: () => void;
+}
+
+const initialFilters: JobSearchFilters = {
+  position: undefined,
+  experience: undefined,
+  skills: [],
+  source: undefined,
+  location: undefined,
+};
+
+const useJobStore = create<JobStore>((set) => ({
+  searchQuery: "",
+  filters: initialFilters,
+  setSearchQuery: (query) => set({ searchQuery: query }),
+  setFilter: (key, value) =>
+    set((state) => ({
+      filters: { ...state.filters, [key]: value },
+    })),
+  resetFilters: () => set({ filters: initialFilters, searchQuery: "" }),
+}));
+
+export default useJobStore;


### PR DESCRIPTION
## Summary
- Add sticky responsive `GlobalNavbar` with search bar, nav links (채용공고/이력서/마이페이지), mobile hamburger menu, and auth-aware profile dropdown
- Add `GlobalLayout` wrapping navbar + footer for all new job-related pages
- Add `JobListPage` (`/jobs`) — filter sidebar (position/experience/location/source), infinite-scroll job card grid, source badges (원티드=blue, 사람인=green, 잡코리아=orange)
- Add `JobDetailPage` (`/jobs/:id`) — full job info, skills tags, "지원하기" button (`window.open` + `POST /api/v1/events`), bookmark toggle, similar jobs section
- Add `JobSearchPage` (`/jobs/search?q=...`) routing to JobListPage with query param
- Add `src/api/jobApi.ts` — `searchJobs`, `getJobDetail`, `getSimilarJobs`, `getAutocomplete`, `recordEvent`
- Add `src/store/jobStore.ts` (Zustand) — filters state + `setFilter` / `resetFilters` actions
- Wire new routes `/jobs`, `/jobs/search`, `/jobs/:id` into `App.tsx` alongside existing routes

## Design
- Primary color: blue (`#2563eb`) for professional feel
- Tailwind-only for all new components (no new MUI usage)
- Lucide icons throughout
- Responsive at 375px / 768px / 1024px / 1440px

## Test plan
- [ ] Navigate to `/jobs` — job list page renders with filter sidebar and card grid
- [ ] Apply position/experience/location/source filters — card grid re-fetches with filters
- [ ] Click a job card — navigates to `/jobs/:id` detail page
- [ ] Click "지원하기" on detail page — opens source URL in new tab and records APPLY_CLICK event
- [ ] Click bookmark — toggles bookmark state and records BOOKMARK event
- [ ] Enter search in navbar → navigates to `/jobs/search?q=...`
- [ ] Mobile: hamburger menu opens/closes slide-out nav at 375px
- [ ] Existing routes `/`, `/login`, `/search`, `/feedback/:id`, `/upload`, `/myInfo`, `/Auth` remain unaffected
- [ ] `tsc --noEmit` passes with zero errors
- [ ] `vite build` succeeds