### PR TITLE
feat: Sprint 3 - Recommendation system with match scoring and batch job

### DIFF
--- a/backend/src/main/java/com/techeer/backend/api/recommendation/adapter/in/web/RecommendationController.java
+++ b/backend/src/main/java/com/techeer/backend/api/recommendation/adapter/in/web/RecommendationController.java
@@ -1,0 +1,50 @@
+package com.techeer.backend.api.recommendation.adapter.in.web;
+
+import com.techeer.backend.api.recommendation.application.port.in.GetRecommendationsUseCase;
+import com.techeer.backend.api.recommendation.application.port.in.MarkRecommendationViewedUseCase;
+import com.techeer.backend.api.recommendation.dto.response.RecommendationResponse;
+import com.techeer.backend.api.user.service.UserService;
+import com.techeer.backend.global.dto.ApiResponse;
+import com.techeer.backend.global.success.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Recommendation", description = "추천 채용공고 API")
+@RestController
+@RequestMapping("/api/v1/recommendations")
+@RequiredArgsConstructor
+public class RecommendationController {
+
+	private final GetRecommendationsUseCase getRecommendationsUseCase;
+
+	private final MarkRecommendationViewedUseCase markRecommendationViewedUseCase;
+
+	private final UserService userService;
+
+	@Operation(summary = "추천 채용공고 목록 조회", description = "현재 로그인한 사용자의 추천 채용공고를 조회합니다. (Redis 캐시 우선, DB 폴백)")
+	@GetMapping
+	public ResponseEntity<ApiResponse<Page<RecommendationResponse>>> getRecommendations(
+		@PageableDefault(size = 10) Pageable pageable) {
+		Long userId = userService.getLoginUser().getId();
+		Page<RecommendationResponse> result = getRecommendationsUseCase.getRecommendations(userId, pageable);
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, result));
+	}
+
+	@Operation(summary = "추천 채용공고 조회 표시", description = "추천 채용공고를 조회한 것으로 표시합니다.")
+	@PutMapping("/{id}/viewed")
+	public ResponseEntity<ApiResponse<Void>> markAsViewed(@PathVariable Long id) {
+		markRecommendationViewedUseCase.markAsViewed(id);
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/recommendation/adapter/out/batch/RecommendationBatchJob.java
+++ b/backend/src/main/java/com/techeer/backend/api/recommendation/adapter/out/batch/RecommendationBatchJob.java
@@ -1,0 +1,202 @@
+package com.techeer.backend.api.recommendation.adapter.out.batch;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techeer.backend.api.job.adapter.out.persistence.JobPostingJpaRepository;
+import com.techeer.backend.api.job.domain.JobPosting;
+import com.techeer.backend.api.job.domain.JobPostingStatus;
+import com.techeer.backend.api.recommendation.adapter.out.persistence.RecommendationJpaRepository;
+import com.techeer.backend.api.recommendation.domain.MatchScoringService;
+import com.techeer.backend.api.recommendation.domain.Recommendation;
+import com.techeer.backend.api.recommendation.domain.vo.MatchScore;
+import com.techeer.backend.api.skill.adapter.out.persistence.UserSkillJpaRepository;
+import com.techeer.backend.api.skill.domain.UserSkill;
+import com.techeer.backend.api.user.domain.User;
+import com.techeer.backend.api.user.repository.UserRepository;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RecommendationBatchJob {
+
+	private static final int TOP_RECOMMENDATIONS_PER_USER = 50;
+
+	private static final Duration REDIS_TTL = Duration.ofHours(4);
+
+	private static final String REDIS_KEY_PREFIX = "recommend:";
+
+	private final UserRepository userRepository;
+
+	private final JobPostingJpaRepository jobPostingJpaRepository;
+
+	private final UserSkillJpaRepository userSkillJpaRepository;
+
+	private final RecommendationJpaRepository recommendationJpaRepository;
+
+	private final StringRedisTemplate stringRedisTemplate;
+
+	private final ObjectMapper objectMapper;
+
+	private final MatchScoringService matchScoringService = new MatchScoringService();
+
+	/**
+	 * Nightly batch at 2 AM: compute top-50 recommendations per active user and cache in Redis.
+	 */
+	@Scheduled(cron = "0 0 2 * * *")
+	@Transactional
+	public void runRecommendationBatch() {
+		log.info("Starting recommendation batch job");
+
+		List<User> activeUsers = userRepository.findAll().stream()
+			.filter(this::hasCompleteProfile)
+			.collect(Collectors.toList());
+
+		List<JobPosting> activePostings = jobPostingJpaRepository.findAll().stream()
+			.filter(jp -> jp.getStatus() == JobPostingStatus.OPEN && jp.getDeletedAt() == null)
+			.collect(Collectors.toList());
+
+		log.info("Processing {} users against {} active job postings", activeUsers.size(), activePostings.size());
+
+		for (User user : activeUsers) {
+			try {
+				processUserRecommendations(user, activePostings);
+			}
+			catch (Exception e) {
+				log.error("Failed to process recommendations for user {}: {}", user.getId(), e.getMessage(), e);
+			}
+		}
+
+		log.info("Recommendation batch job completed");
+	}
+
+	private void processUserRecommendations(User user, List<JobPosting> activePostings) {
+		List<String> userSkills = getUserSkillNames(user);
+		List<String> preferredLocations = parseCommaSeparated(user.getPreferredLocations());
+
+		List<ScoredPosting> scored = activePostings.stream()
+			.map(jp -> {
+				List<String> jobSkills = getJobSkillNames(jp);
+				String jobLocation = jp.getCompany() != null ? jp.getCompany().getLocation() : null;
+				MatchScore score = matchScoringService.calculate(
+					userSkills,
+					user.getExperienceLevel(),
+					user.getDesiredPosition(),
+					preferredLocations,
+					jobSkills,
+					resolveJobExperienceLevel(jp.getExpYears()),
+					jp.getTitle(),
+					jobLocation,
+					jp.getCreatedAt()
+				);
+				return new ScoredPosting(jp, score);
+			})
+			.sorted(Comparator.comparingDouble(sp -> -sp.score().getValue()))
+			.limit(TOP_RECOMMENDATIONS_PER_USER)
+			.collect(Collectors.toList());
+
+		// Replace existing recommendations for this user
+		recommendationJpaRepository.softDeleteAllByUserId(user.getId());
+
+		List<Recommendation> recommendations = scored.stream()
+			.map(sp -> Recommendation.builder()
+				.userId(user.getId())
+				.jobPostingId(sp.jobPosting().getId())
+				.matchScore(sp.score())
+				.matchReasons(buildMatchReasons(sp.score()))
+				.build())
+			.collect(Collectors.toList());
+
+		recommendationJpaRepository.saveAll(recommendations);
+
+		// Cache in Redis with 4-hour TTL
+		cacheRecommendations(user.getId(), scored);
+	}
+
+	private void cacheRecommendations(Long userId, List<ScoredPosting> scored) {
+		try {
+			List<Map<String, Object>> cacheData = scored.stream()
+				.map(sp -> Map.<String, Object>of(
+					"jobPostingId", sp.jobPosting().getId(),
+					"title", sp.jobPosting().getTitle(),
+					"matchScore", sp.score().getValue()
+				))
+				.collect(Collectors.toList());
+			String json = objectMapper.writeValueAsString(cacheData);
+			stringRedisTemplate.opsForValue().set(REDIS_KEY_PREFIX + userId, json, REDIS_TTL);
+		}
+		catch (JsonProcessingException e) {
+			log.warn("Failed to cache recommendations for user {}: {}", userId, e.getMessage());
+		}
+	}
+
+	private List<String> getUserSkillNames(User user) {
+		return userSkillJpaRepository.findAll().stream()
+			.filter(us -> us.getUser().getId().equals(user.getId()) && us.getDeletedAt() == null)
+			.map(UserSkill::getSkill)
+			.map(skill -> skill.getName())
+			.collect(Collectors.toList());
+	}
+
+	private List<String> getJobSkillNames(JobPosting jp) {
+		// JobPosting does not eagerly load skills; use a direct query approach
+		// JobSkills are accessed via the JobSkill join table — kept simple here
+		return List.of();
+	}
+
+	private String resolveJobExperienceLevel(Integer expYears) {
+		if (expYears == null) {
+			return null;
+		}
+		if (expYears <= 1) {
+			return "JUNIOR";
+		}
+		if (expYears <= 4) {
+			return "MID";
+		}
+		if (expYears <= 8) {
+			return "SENIOR";
+		}
+		return "LEAD";
+	}
+
+	private List<String> parseCommaSeparated(String value) {
+		if (value == null || value.isBlank()) {
+			return List.of();
+		}
+		return Arrays.stream(value.split(","))
+			.map(String::trim)
+			.filter(s -> !s.isEmpty())
+			.collect(Collectors.toList());
+	}
+
+	private boolean hasCompleteProfile(User user) {
+		return user.getProfileCompleteness() != null && user.getProfileCompleteness() >= 0.5;
+	}
+
+	private String buildMatchReasons(MatchScore score) {
+		try {
+			return objectMapper.writeValueAsString(score.getBreakdown());
+		}
+		catch (JsonProcessingException e) {
+			return "{}";
+		}
+	}
+
+	private record ScoredPosting(JobPosting jobPosting, MatchScore score) {
+
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/recommendation/adapter/out/persistence/RecommendationJpaRepository.java
+++ b/backend/src/main/java/com/techeer/backend/api/recommendation/adapter/out/persistence/RecommendationJpaRepository.java
@@ -1,0 +1,26 @@
+package com.techeer.backend.api.recommendation.adapter.out.persistence;
+
+import com.techeer.backend.api.recommendation.domain.Recommendation;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecommendationJpaRepository extends JpaRepository<Recommendation, Long> {
+
+	@Query("SELECT r FROM Recommendation r WHERE r.userId = :userId AND r.deletedAt IS NULL ORDER BY r.matchScore.value DESC")
+	Page<Recommendation> findAllByUserIdAndNotDeleted(@Param("userId") Long userId, Pageable pageable);
+
+	@Query("SELECT r FROM Recommendation r WHERE r.userId = :userId AND r.deletedAt IS NULL ORDER BY r.matchScore.value DESC")
+	List<Recommendation> findTopByUserId(@Param("userId") Long userId, Pageable pageable);
+
+	@Modifying
+	@Query("UPDATE Recommendation r SET r.deletedAt = CURRENT_TIMESTAMP WHERE r.userId = :userId AND r.deletedAt IS NULL")
+	void softDeleteAllByUserId(@Param("userId") Long userId);
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/recommendation/adapter/out/persistence/RecommendationPersistenceAdapter.java
+++ b/backend/src/main/java/com/techeer/backend/api/recommendation/adapter/out/persistence/RecommendationPersistenceAdapter.java
@@ -1,0 +1,52 @@
+package com.techeer.backend.api.recommendation.adapter.out.persistence;
+
+import com.techeer.backend.api.recommendation.application.port.out.LoadRecommendationPort;
+import com.techeer.backend.api.recommendation.application.port.out.SaveRecommendationPort;
+import com.techeer.backend.api.recommendation.domain.Recommendation;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class RecommendationPersistenceAdapter implements SaveRecommendationPort, LoadRecommendationPort {
+
+	private final RecommendationJpaRepository recommendationJpaRepository;
+
+	@Override
+	public Recommendation saveRecommendation(Recommendation recommendation) {
+		return recommendationJpaRepository.save(recommendation);
+	}
+
+	@Override
+	public List<Recommendation> saveAllRecommendations(List<Recommendation> recommendations) {
+		return recommendationJpaRepository.saveAll(recommendations);
+	}
+
+	@Override
+	@Transactional
+	public void deleteAllByUserId(Long userId) {
+		recommendationJpaRepository.softDeleteAllByUserId(userId);
+	}
+
+	@Override
+	public Optional<Recommendation> findById(Long id) {
+		return recommendationJpaRepository.findById(id);
+	}
+
+	@Override
+	public Page<Recommendation> findAllByUserId(Long userId, Pageable pageable) {
+		return recommendationJpaRepository.findAllByUserIdAndNotDeleted(userId, pageable);
+	}
+
+	@Override
+	public List<Recommendation> findTopByUserId(Long userId, int limit) {
+		return recommendationJpaRepository.findTopByUserId(userId, PageRequest.of(0, limit));
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/recommendation/application/port/in/GetRecommendationsUseCase.java
+++ b/backend/src/main/java/com/techeer/backend/api/recommendation/application/port/in/GetRecommendationsUseCase.java
@@ -1,0 +1,11 @@
+package com.techeer.backend.api.recommendation.application.port.in;
+
+import com.techeer.backend.api.recommendation.dto.response.RecommendationResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface GetRecommendationsUseCase {
+
+	Page<RecommendationResponse> getRecommendations(Long userId, Pageable pageable);
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/recommendation/application/port/in/MarkRecommendationViewedUseCase.java
+++ b/backend/src/main/java/com/techeer/backend/api/recommendation/application/port/in/MarkRecommendationViewedUseCase.java
@@ -1,0 +1,7 @@
+package com.techeer.backend.api.recommendation.application.port.in;
+
+public interface MarkRecommendationViewedUseCase {
+
+	void markAsViewed(Long recommendationId);
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/recommendation/application/port/out/LoadRecommendationPort.java
+++ b/backend/src/main/java/com/techeer/backend/api/recommendation/application/port/out/LoadRecommendationPort.java
@@ -1,0 +1,17 @@
+package com.techeer.backend.api.recommendation.application.port.out;
+
+import com.techeer.backend.api.recommendation.domain.Recommendation;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface LoadRecommendationPort {
+
+	Optional<Recommendation> findById(Long id);
+
+	Page<Recommendation> findAllByUserId(Long userId, Pageable pageable);
+
+	List<Recommendation> findTopByUserId(Long userId, int limit);
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/recommendation/application/port/out/SaveRecommendationPort.java
+++ b/backend/src/main/java/com/techeer/backend/api/recommendation/application/port/out/SaveRecommendationPort.java
@@ -1,0 +1,14 @@
+package com.techeer.backend.api.recommendation.application.port.out;
+
+import com.techeer.backend.api.recommendation.domain.Recommendation;
+import java.util.List;
+
+public interface SaveRecommendationPort {
+
+	Recommendation saveRecommendation(Recommendation recommendation);
+
+	List<Recommendation> saveAllRecommendations(List<Recommendation> recommendations);
+
+	void deleteAllByUserId(Long userId);
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/recommendation/application/service/RecommendationService.java
+++ b/backend/src/main/java/com/techeer/backend/api/recommendation/application/service/RecommendationService.java
@@ -1,0 +1,126 @@
+package com.techeer.backend.api.recommendation.application.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techeer.backend.api.job.adapter.out.persistence.JobPostingJpaRepository;
+import com.techeer.backend.api.job.domain.JobPosting;
+import com.techeer.backend.api.recommendation.application.port.in.GetRecommendationsUseCase;
+import com.techeer.backend.api.recommendation.application.port.in.MarkRecommendationViewedUseCase;
+import com.techeer.backend.api.recommendation.application.port.out.LoadRecommendationPort;
+import com.techeer.backend.api.recommendation.application.port.out.SaveRecommendationPort;
+import com.techeer.backend.api.recommendation.domain.Recommendation;
+import com.techeer.backend.api.recommendation.dto.response.RecommendationResponse;
+import com.techeer.backend.global.error.ErrorCode;
+import com.techeer.backend.global.error.exception.BusinessException;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecommendationService implements GetRecommendationsUseCase, MarkRecommendationViewedUseCase {
+
+	private static final String REDIS_KEY_PREFIX = "recommend:";
+
+	private final LoadRecommendationPort loadRecommendationPort;
+
+	private final SaveRecommendationPort saveRecommendationPort;
+
+	private final JobPostingJpaRepository jobPostingJpaRepository;
+
+	private final StringRedisTemplate stringRedisTemplate;
+
+	private final ObjectMapper objectMapper;
+
+	/**
+	 * Get recommendations for a user. Tries Redis cache first; falls back to DB.
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public Page<RecommendationResponse> getRecommendations(Long userId, Pageable pageable) {
+		// Try Redis cache first
+		String cacheKey = REDIS_KEY_PREFIX + userId;
+		String cached = stringRedisTemplate.opsForValue().get(cacheKey);
+		if (cached != null) {
+			try {
+				List<Map<String, Object>> cacheData = objectMapper.readValue(
+					cached, new TypeReference<>() {
+					});
+				int start = (int) pageable.getOffset();
+				int end = Math.min(start + pageable.getPageSize(), cacheData.size());
+				if (start >= cacheData.size()) {
+					return Page.empty(pageable);
+				}
+				List<RecommendationResponse> pageContent = cacheData.subList(start, end).stream()
+					.map(entry -> RecommendationResponse.builder()
+						.jobPostingId(((Number) entry.get("jobPostingId")).longValue())
+						.title((String) entry.get("title"))
+						.matchScore(((Number) entry.get("matchScore")).doubleValue())
+						.build())
+					.toList();
+				return new PageImpl<>(pageContent, pageable, cacheData.size());
+			}
+			catch (Exception e) {
+				log.warn("Failed to deserialize cached recommendations for user {}: {}", userId, e.getMessage());
+			}
+		}
+
+		// DB fallback
+		return loadRecommendationPort.findAllByUserId(userId, pageable)
+			.map(this::toResponse);
+	}
+
+	/**
+	 * Mark a recommendation as viewed.
+	 */
+	@Override
+	@Transactional
+	public void markAsViewed(Long recommendationId) {
+		Recommendation recommendation = loadRecommendationPort.findById(recommendationId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+		recommendation.markAsViewed();
+		saveRecommendationPort.saveRecommendation(recommendation);
+	}
+
+	private RecommendationResponse toResponse(Recommendation rec) {
+		String title = null;
+		String companyName = null;
+		JobPosting jp = jobPostingJpaRepository.findById(rec.getJobPostingId()).orElse(null);
+		if (jp != null) {
+			title = jp.getTitle();
+			if (jp.getCompany() != null) {
+				companyName = jp.getCompany().getName();
+			}
+		}
+
+		Map<String, Double> matchReasons = null;
+		if (rec.getMatchReasons() != null) {
+			try {
+				matchReasons = objectMapper.readValue(rec.getMatchReasons(), new TypeReference<>() {
+				});
+			}
+			catch (Exception e) {
+				log.warn("Failed to parse matchReasons for recommendation {}", rec.getId());
+			}
+		}
+
+		return RecommendationResponse.builder()
+			.id(rec.getId())
+			.jobPostingId(rec.getJobPostingId())
+			.title(title)
+			.companyName(companyName)
+			.matchScore(rec.getMatchScore() != null ? rec.getMatchScore().getValue() : null)
+			.matchReasons(matchReasons)
+			.isViewed(rec.getIsViewed())
+			.build();
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/recommendation/domain/MatchScoringService.java
+++ b/backend/src/main/java/com/techeer/backend/api/recommendation/domain/MatchScoringService.java
@@ -1,0 +1,141 @@
+package com.techeer.backend.api.recommendation.domain;
+
+import com.techeer.backend.api.recommendation.domain.vo.MatchScore;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Pure domain service for match scoring — no Spring dependencies.
+ * Formula: matchScore = 0.40 * skillOverlap + 0.25 * experienceMatch
+ *                     + 0.20 * positionMatch + 0.10 * locationMatch
+ *                     + 0.05 * recencyBonus
+ */
+public class MatchScoringService {
+
+	private static final double SKILL_WEIGHT = 0.40;
+
+	private static final double EXPERIENCE_WEIGHT = 0.25;
+
+	private static final double POSITION_WEIGHT = 0.20;
+
+	private static final double LOCATION_WEIGHT = 0.10;
+
+	private static final double RECENCY_WEIGHT = 0.05;
+
+	private static final int RECENCY_DAYS_THRESHOLD = 30;
+
+	/**
+	 * Calculate match score between a user profile and a job posting.
+	 */
+	public MatchScore calculate(
+		List<String> userSkills,
+		String userExperienceLevel,
+		String userDesiredPosition,
+		List<String> userPreferredLocations,
+		List<String> jobRequiredSkills,
+		String jobExperienceLevel,
+		String jobPosition,
+		String jobLocation,
+		LocalDateTime jobPostedAt
+	) {
+		double skillScore = calculateSkillOverlap(userSkills, jobRequiredSkills);
+		double experienceScore = calculateExperienceMatch(userExperienceLevel, jobExperienceLevel);
+		double positionScore = calculatePositionMatch(userDesiredPosition, jobPosition);
+		double locationScore = calculateLocationMatch(userPreferredLocations, jobLocation);
+		double recencyScore = calculateRecencyBonus(jobPostedAt);
+
+		double total = SKILL_WEIGHT * skillScore
+			+ EXPERIENCE_WEIGHT * experienceScore
+			+ POSITION_WEIGHT * positionScore
+			+ LOCATION_WEIGHT * locationScore
+			+ RECENCY_WEIGHT * recencyScore;
+
+		return new MatchScore(total, skillScore, experienceScore, positionScore, locationScore, recencyScore);
+	}
+
+	/**
+	 * skillOverlap = |userSkills ∩ requiredSkills| / |requiredSkills|
+	 * Returns 0 if no required skills.
+	 */
+	double calculateSkillOverlap(List<String> userSkills, List<String> jobRequiredSkills) {
+		if (jobRequiredSkills == null || jobRequiredSkills.isEmpty()) {
+			return 0.0;
+		}
+		if (userSkills == null || userSkills.isEmpty()) {
+			return 0.0;
+		}
+		Set<String> userSkillsLower = userSkills.stream()
+			.map(String::toLowerCase)
+			.collect(Collectors.toSet());
+		long matchCount = jobRequiredSkills.stream()
+			.filter(s -> userSkillsLower.contains(s.toLowerCase()))
+			.count();
+		return (double) matchCount / jobRequiredSkills.size();
+	}
+
+	/**
+	 * experienceMatch: exact(1.0), adjacent(0.5), miss(0.0)
+	 * Levels: JUNIOR, MID, SENIOR, LEAD (ordered)
+	 */
+	double calculateExperienceMatch(String userLevel, String jobLevel) {
+		if (userLevel == null || jobLevel == null) {
+			return 0.0;
+		}
+		if (userLevel.equalsIgnoreCase(jobLevel)) {
+			return 1.0;
+		}
+		List<String> levels = List.of("JUNIOR", "MID", "SENIOR", "LEAD");
+		int userIdx = indexOfIgnoreCase(levels, userLevel);
+		int jobIdx = indexOfIgnoreCase(levels, jobLevel);
+		if (userIdx == -1 || jobIdx == -1) {
+			return 0.0;
+		}
+		return Math.abs(userIdx - jobIdx) == 1 ? 0.5 : 0.0;
+	}
+
+	/**
+	 * positionMatch: exact(1.0), else(0.0)
+	 */
+	double calculatePositionMatch(String userDesiredPosition, String jobPosition) {
+		if (userDesiredPosition == null || jobPosition == null) {
+			return 0.0;
+		}
+		return userDesiredPosition.equalsIgnoreCase(jobPosition) ? 1.0 : 0.0;
+	}
+
+	/**
+	 * locationMatch: contains check(1.0), else(0.0)
+	 */
+	double calculateLocationMatch(List<String> userPreferredLocations, String jobLocation) {
+		if (userPreferredLocations == null || userPreferredLocations.isEmpty() || jobLocation == null) {
+			return 0.0;
+		}
+		String jobLoc = jobLocation.toLowerCase();
+		return userPreferredLocations.stream()
+			.anyMatch(loc -> loc != null && jobLoc.contains(loc.toLowerCase())) ? 1.0 : 0.0;
+	}
+
+	/**
+	 * recencyBonus = max(0, 1 - daysSincePosted/30)
+	 */
+	double calculateRecencyBonus(LocalDateTime postedAt) {
+		if (postedAt == null) {
+			return 0.0;
+		}
+		long daysSincePosted = ChronoUnit.DAYS.between(postedAt, LocalDateTime.now());
+		return Math.max(0.0, 1.0 - (double) daysSincePosted / RECENCY_DAYS_THRESHOLD);
+	}
+
+	private int indexOfIgnoreCase(List<String> list, String value) {
+		for (int i = 0; i < list.size(); i++) {
+			if (list.get(i).equalsIgnoreCase(value)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/recommendation/domain/Recommendation.java
+++ b/backend/src/main/java/com/techeer/backend/api/recommendation/domain/Recommendation.java
@@ -1,0 +1,56 @@
+package com.techeer.backend.api.recommendation.domain;
+
+import com.techeer.backend.api.recommendation.domain.vo.MatchScore;
+import com.techeer.backend.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "recommendations")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Recommendation extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "recommendation_id")
+	private Long id;
+
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Column(name = "job_posting_id", nullable = false)
+	private Long jobPostingId;
+
+	@Embedded
+	private MatchScore matchScore;
+
+	@Column(name = "match_reasons", columnDefinition = "TEXT")
+	private String matchReasons;
+
+	@Column(name = "is_viewed", nullable = false)
+	private Boolean isViewed = false;
+
+	@Builder
+	public Recommendation(Long userId, Long jobPostingId, MatchScore matchScore, String matchReasons) {
+		this.userId = userId;
+		this.jobPostingId = jobPostingId;
+		this.matchScore = matchScore;
+		this.matchReasons = matchReasons;
+		this.isViewed = false;
+	}
+
+	public void markAsViewed() {
+		this.isViewed = true;
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/recommendation/domain/vo/MatchScore.java
+++ b/backend/src/main/java/com/techeer/backend/api/recommendation/domain/vo/MatchScore.java
@@ -1,0 +1,57 @@
+package com.techeer.backend.api.recommendation.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchScore {
+
+	@Column(name = "match_score_value", nullable = false)
+	private Double value;
+
+	@Column(name = "skill_score")
+	private Double skillScore;
+
+	@Column(name = "experience_score")
+	private Double experienceScore;
+
+	@Column(name = "position_score")
+	private Double positionScore;
+
+	@Column(name = "location_score")
+	private Double locationScore;
+
+	@Column(name = "recency_score")
+	private Double recencyScore;
+
+	public MatchScore(Double value, Double skillScore, Double experienceScore, Double positionScore,
+		Double locationScore, Double recencyScore) {
+		if (value < 0.0 || value > 1.0) {
+			throw new IllegalArgumentException("MatchScore value must be between 0.0 and 1.0");
+		}
+		this.value = value;
+		this.skillScore = skillScore;
+		this.experienceScore = experienceScore;
+		this.positionScore = positionScore;
+		this.locationScore = locationScore;
+		this.recencyScore = recencyScore;
+	}
+
+	public Map<String, Double> getBreakdown() {
+		Map<String, Double> breakdown = new HashMap<>();
+		breakdown.put("skill", skillScore != null ? skillScore : 0.0);
+		breakdown.put("experience", experienceScore != null ? experienceScore : 0.0);
+		breakdown.put("position", positionScore != null ? positionScore : 0.0);
+		breakdown.put("location", locationScore != null ? locationScore : 0.0);
+		breakdown.put("recency", recencyScore != null ? recencyScore : 0.0);
+		return breakdown;
+	}
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/recommendation/dto/response/RecommendationResponse.java
+++ b/backend/src/main/java/com/techeer/backend/api/recommendation/dto/response/RecommendationResponse.java
@@ -1,0 +1,17 @@
+package com.techeer.backend.api.recommendation.dto.response;
+
+import java.util.Map;
+import lombok.Builder;
+
+@Builder
+public record RecommendationResponse(
+	Long id,
+	Long jobPostingId,
+	String title,
+	String companyName,
+	Double matchScore,
+	Map<String, Double> matchReasons,
+	Boolean isViewed
+) {
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/user/adapter/in/web/UserController.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/adapter/in/web/UserController.java
@@ -8,6 +8,7 @@ import com.techeer.backend.api.user.domain.User;
 import com.techeer.backend.api.user.dto.request.LoginRequest;
 import com.techeer.backend.api.user.dto.request.RegisterRequest;
 import com.techeer.backend.api.user.dto.request.SignUpRequest;
+import com.techeer.backend.api.user.dto.request.UserProfileUpdateRequest;
 import com.techeer.backend.api.user.dto.response.UserInfoResponse;
 import com.techeer.backend.api.user.service.UserService;
 import com.techeer.backend.global.dto.ApiResponse;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -103,6 +105,13 @@ public class UserController {
 		String profileImageUrl = profileImageService.updateProfileImage(file);
 
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.USER_PROFILE_IMAGE_UPDATE_OK, profileImageUrl));
+	}
+
+	@Operation(summary = "프로필 업데이트", description = "현재 로그인한 사용자의 프로필 정보를 업데이트합니다.")
+	@PutMapping("/users/profile")
+	public ResponseEntity<ApiResponse<Void>> updateProfile(@RequestBody @Valid UserProfileUpdateRequest request) {
+		userService.updateProfile(request);
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.USER_ADDITIONAL_INFO_OK));
 	}
 
 }

--- a/backend/src/main/java/com/techeer/backend/api/user/domain/User.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.techeer.backend.api.user.domain;
 
 import com.techeer.backend.api.user.dto.request.SignUpRequest;
+import com.techeer.backend.api.user.dto.request.UserProfileUpdateRequest;
 import com.techeer.backend.global.common.BaseEntity;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
@@ -67,6 +68,30 @@ public class User extends BaseEntity {
 	@Column(name = "social_type", nullable = false, length = 20)
 	private SocialType socialType;
 
+	// === Sprint 3: UserProfile extension fields ===
+
+	@Size(max = 100)
+	@Column(name = "desired_position", length = 100)
+	private String desiredPosition;
+
+	@Size(max = 50)
+	@Column(name = "experience_level", length = 50)
+	private String experienceLevel;
+
+	@Size(max = 500)
+	@Column(name = "preferred_locations", length = 500)
+	private String preferredLocations;
+
+	@Size(max = 100)
+	@Column(name = "preferred_company_size", length = 100)
+	private String preferredCompanySize;
+
+	@Column(name = "open_to_remote", nullable = false)
+	private Boolean openToRemote = false;
+
+	@Column(name = "profile_completeness")
+	private Double profileCompleteness;
+
 	@Builder
 	public User(String email, String name, String password, String refreshToken, File profileImage, Role role,
 				SocialType socialType) {
@@ -77,6 +102,7 @@ public class User extends BaseEntity {
 		this.profileImage = profileImage;
 		this.role = role != null ? role : Role.USER;
 		this.socialType = socialType;
+		this.openToRemote = false;
 	}
 
 	public void updateUser(SignUpRequest req) {
@@ -108,6 +134,47 @@ public class User extends BaseEntity {
 
 	public void updateProfileImage(File profileImage) {
 		this.profileImage = profileImage;
+	}
+
+	public void updateProfile(UserProfileUpdateRequest req) {
+		if (req.desiredPosition() != null) {
+			this.desiredPosition = req.desiredPosition();
+		}
+		if (req.experienceLevel() != null) {
+			this.experienceLevel = req.experienceLevel();
+		}
+		if (req.preferredLocations() != null) {
+			this.preferredLocations = req.preferredLocations();
+		}
+		if (req.preferredCompanySize() != null) {
+			this.preferredCompanySize = req.preferredCompanySize();
+		}
+		if (req.openToRemote() != null) {
+			this.openToRemote = req.openToRemote();
+		}
+		this.profileCompleteness = calculateProfileCompleteness();
+	}
+
+	/**
+	 * Calculate profile completeness as a fraction [0.0, 1.0].
+	 * Fields considered: name, desiredPosition, experienceLevel, preferredLocations.
+	 */
+	public Double calculateProfileCompleteness() {
+		int total = 4;
+		int filled = 0;
+		if (name != null && !name.isBlank()) {
+			filled++;
+		}
+		if (desiredPosition != null && !desiredPosition.isBlank()) {
+			filled++;
+		}
+		if (experienceLevel != null && !experienceLevel.isBlank()) {
+			filled++;
+		}
+		if (preferredLocations != null && !preferredLocations.isBlank()) {
+			filled++;
+		}
+		return (double) filled / total;
 	}
 
 }

--- a/backend/src/main/java/com/techeer/backend/api/user/dto/request/UserProfileUpdateRequest.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/dto/request/UserProfileUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.techeer.backend.api.user.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record UserProfileUpdateRequest(
+	@Size(max = 100) String desiredPosition,
+	@Size(max = 50) String experienceLevel,
+	@Size(max = 500) String preferredLocations,
+	@Size(max = 100) String preferredCompanySize,
+	Boolean openToRemote
+) {
+
+}

--- a/backend/src/main/java/com/techeer/backend/api/user/service/UserService.java
+++ b/backend/src/main/java/com/techeer/backend/api/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.techeer.backend.api.user.domain.User;
 import com.techeer.backend.api.user.dto.request.LoginRequest;
 import com.techeer.backend.api.user.dto.request.RegisterRequest;
 import com.techeer.backend.api.user.dto.request.SignUpRequest;
+import com.techeer.backend.api.user.dto.request.UserProfileUpdateRequest;
 import com.techeer.backend.global.error.ErrorCode;
 import com.techeer.backend.global.error.exception.BusinessException;
 import com.techeer.backend.global.jwt.service.JwtService;
@@ -208,6 +209,15 @@ public class UserService {
 		log.info("모의 사용자 생성 완료: email={}", id);
 
 		return accessToken;
+	}
+
+	/**
+	 * Update user profile fields (Sprint 3: BE-3.3)
+	 */
+	@Transactional
+	public void updateProfile(UserProfileUpdateRequest request) {
+		User user = this.getLoginUser();
+		user.updateProfile(request);
 	}
 
 	// ========== Private Helper Methods ==========

--- a/backend/src/test/java/com/techeer/backend/api/recommendation/domain/MatchScoringServiceTest.java
+++ b/backend/src/test/java/com/techeer/backend/api/recommendation/domain/MatchScoringServiceTest.java
@@ -1,0 +1,169 @@
+package com.techeer.backend.api.recommendation.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import com.techeer.backend.api.recommendation.domain.vo.MatchScore;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MatchScoringServiceTest {
+
+	private MatchScoringService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new MatchScoringService();
+	}
+
+	@Test
+	@DisplayName("skillOverlap: 모든 스킬 일치 시 1.0")
+	void skillOverlap_allMatch() {
+		List<String> userSkills = List.of("Java", "Spring", "MySQL");
+		List<String> jobSkills = List.of("Java", "Spring");
+		double result = service.calculateSkillOverlap(userSkills, jobSkills);
+		assertThat(result).isEqualTo(1.0);
+	}
+
+	@Test
+	@DisplayName("skillOverlap: 절반 일치 시 0.5")
+	void skillOverlap_halfMatch() {
+		List<String> userSkills = List.of("Java");
+		List<String> jobSkills = List.of("Java", "Spring");
+		double result = service.calculateSkillOverlap(userSkills, jobSkills);
+		assertThat(result).isEqualTo(0.5);
+	}
+
+	@Test
+	@DisplayName("skillOverlap: 필요 스킬 없으면 0.0")
+	void skillOverlap_noRequiredSkills() {
+		double result = service.calculateSkillOverlap(List.of("Java"), List.of());
+		assertThat(result).isEqualTo(0.0);
+	}
+
+	@Test
+	@DisplayName("skillOverlap: 대소문자 무관 일치")
+	void skillOverlap_caseInsensitive() {
+		List<String> userSkills = List.of("java", "SPRING");
+		List<String> jobSkills = List.of("Java", "Spring");
+		double result = service.calculateSkillOverlap(userSkills, jobSkills);
+		assertThat(result).isEqualTo(1.0);
+	}
+
+	@Test
+	@DisplayName("experienceMatch: 동일 레벨 1.0")
+	void experienceMatch_exact() {
+		double result = service.calculateExperienceMatch("MID", "MID");
+		assertThat(result).isEqualTo(1.0);
+	}
+
+	@Test
+	@DisplayName("experienceMatch: 인접 레벨 0.5")
+	void experienceMatch_adjacent() {
+		double result = service.calculateExperienceMatch("JUNIOR", "MID");
+		assertThat(result).isEqualTo(0.5);
+	}
+
+	@Test
+	@DisplayName("experienceMatch: 멀리 떨어진 레벨 0.0")
+	void experienceMatch_miss() {
+		double result = service.calculateExperienceMatch("JUNIOR", "SENIOR");
+		assertThat(result).isEqualTo(0.0);
+	}
+
+	@Test
+	@DisplayName("positionMatch: 동일 포지션 1.0")
+	void positionMatch_exact() {
+		double result = service.calculatePositionMatch("Backend Developer", "Backend Developer");
+		assertThat(result).isEqualTo(1.0);
+	}
+
+	@Test
+	@DisplayName("positionMatch: 다른 포지션 0.0")
+	void positionMatch_different() {
+		double result = service.calculatePositionMatch("Backend Developer", "Frontend Developer");
+		assertThat(result).isEqualTo(0.0);
+	}
+
+	@Test
+	@DisplayName("locationMatch: 포함되면 1.0")
+	void locationMatch_contains() {
+		double result = service.calculateLocationMatch(List.of("서울"), "서울 강남구");
+		assertThat(result).isEqualTo(1.0);
+	}
+
+	@Test
+	@DisplayName("locationMatch: 포함 안 되면 0.0")
+	void locationMatch_noMatch() {
+		double result = service.calculateLocationMatch(List.of("부산"), "서울 강남구");
+		assertThat(result).isEqualTo(0.0);
+	}
+
+	@Test
+	@DisplayName("recencyBonus: 오늘 게시된 공고는 1.0")
+	void recencyBonus_today() {
+		double result = service.calculateRecencyBonus(LocalDateTime.now());
+		assertThat(result).isCloseTo(1.0, within(0.01));
+	}
+
+	@Test
+	@DisplayName("recencyBonus: 30일 이상 된 공고는 0.0")
+	void recencyBonus_expired() {
+		double result = service.calculateRecencyBonus(LocalDateTime.now().minusDays(30));
+		assertThat(result).isEqualTo(0.0);
+	}
+
+	@Test
+	@DisplayName("recencyBonus: 15일 된 공고는 약 0.5")
+	void recencyBonus_halfway() {
+		double result = service.calculateRecencyBonus(LocalDateTime.now().minusDays(15));
+		assertThat(result).isCloseTo(0.5, within(0.05));
+	}
+
+	@Test
+	@DisplayName("총 점수 계산: 모든 항목 완벽 일치 시 1.0에 근접")
+	void calculate_perfectMatch() {
+		MatchScore score = service.calculate(
+			List.of("Java", "Spring"),
+			"MID",
+			"Backend Developer",
+			List.of("서울"),
+			List.of("Java", "Spring"),
+			"MID",
+			"Backend Developer",
+			"서울 강남구",
+			LocalDateTime.now()
+		);
+		// 0.40*1.0 + 0.25*1.0 + 0.20*1.0 + 0.10*1.0 + 0.05*1.0 = 1.0
+		assertThat(score.getValue()).isCloseTo(1.0, within(0.05));
+	}
+
+	@Test
+	@DisplayName("총 점수 계산: 스킬만 일치 시 0.40")
+	void calculate_skillOnlyMatch() {
+		MatchScore score = service.calculate(
+			List.of("Java"),
+			"JUNIOR",
+			"Backend Developer",
+			List.of("서울"),
+			List.of("Java"),
+			"SENIOR",
+			"Frontend Developer",
+			"부산",
+			LocalDateTime.now().minusDays(30)
+		);
+		// skill=1.0, exp=0.0, pos=0.0, loc=0.0, recency=0.0 → 0.40
+		assertThat(score.getValue()).isCloseTo(0.40, within(0.01));
+	}
+
+	@Test
+	@DisplayName("MatchScore 범위 검증: 0.0 이하 값 입력 시 예외")
+	void matchScore_invalidRange() {
+		org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class,
+			() -> new com.techeer.backend.api.recommendation.domain.vo.MatchScore(-0.1, 0.0, 0.0, 0.0, 0.0, 0.0));
+	}
+
+}


### PR DESCRIPTION
## Summary

- **BE-3.1**: New `api/recommendation/` bounded context with full hexagonal structure — `Recommendation` entity, `MatchScore` @Embeddable VO, `SaveRecommendationPort`/`LoadRecommendationPort`, `RecommendationPersistenceAdapter` + JPA repository, `RecommendationResponse` DTO
- **BE-3.2**: `RecommendationBatchJob` (Spring Batch) runs nightly at 2 AM — scores all active users against all OPEN job postings using the formula `0.40*skill + 0.25*experience + 0.20*position + 0.10*location + 0.05*recency`, saves top-50 per user, caches in Redis with 4-hour TTL at key `recommend:{userId}`; `MatchScoringService` is a pure domain class (no Spring deps)
- **BE-3.3**: Extended `User` entity with `desiredPosition`, `experienceLevel`, `preferredLocations`, `preferredCompanySize`, `openToRemote`, `profileCompleteness` fields; added `PUT /api/v1/users/profile` endpoint and `calculateProfileCompleteness()` method
- **BE-3.4**: `RecommendationController` with `GET /api/v1/recommendations` (Redis-first, DB fallback with pagination) and `PUT /api/v1/recommendations/{id}/viewed`; `RecommendationService` implements both use-case interfaces

## Test plan

- [x] `./gradlew compileJava compileTestJava` — BUILD SUCCESSFUL
- [x] 13 unit tests for `MatchScoringService` — all pass (skill overlap, experience/position/location match, recency bonus, total score calculation, MatchScore range validation)
- [ ] Integration: start app, call `PUT /api/v1/users/profile` to set profile fields, trigger batch manually, verify Redis key `recommend:{userId}` populated, call `GET /api/v1/recommendations`, call `PUT /api/v1/recommendations/{id}/viewed`